### PR TITLE
Bug 531950 - Make instances of IResource writable

### DIFF
--- a/org.eclipse.lyo.core.query/src/main/java/org/eclipse/lyo/core/query/impl/PropertiesInvocationHandler.java
+++ b/org.eclipse.lyo.core.query/src/main/java/org/eclipse/lyo/core/query/impl/PropertiesInvocationHandler.java
@@ -3,10 +3,10 @@
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
- * and Eclipse Distribution License v. 1.0 which accompanies this distribution. 
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
  *
  * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Eclipse Distribution License is available at 
+ * and the Eclipse Distribution License is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
@@ -47,7 +47,7 @@ public class PropertiesInvocationHandler implements InvocationHandler
 		this.tree = tree;
 		this.prefixMap = prefixMap;
 	}
-	
+
 	/**
 	 * Construct a {@link Properties} proxy that has a single
 	 * {@link Wildcard} child
@@ -57,15 +57,15 @@ public class PropertiesInvocationHandler implements InvocationHandler
 	{
 		this.tree = null;
 		this.prefixMap = null;
-		
+
 		children = new ArrayList<Property>(1);
-		
+
 		children.add((Property)Proxy.newProxyInstance(
-						Wildcard.class.getClassLoader(), 
+						Wildcard.class.getClassLoader(),
 						new Class<?>[] { Wildcard.class },
 						new WildcardInvocationHandler()));
    }
-	
+
 	/**
 	 * @see java.lang.reflect.InvocationHandler#invoke(java.lang.Object, java.lang.reflect.Method, java.lang.Object[])
 	 */
@@ -74,31 +74,30 @@ public class PropertiesInvocationHandler implements InvocationHandler
 		Object proxy,
 		Method method,
 		Object[] args
-	) throws Throwable
-	{
+	) {
 		boolean isChildren = method.getName().equals("children");
-		
+
 		if (isChildren && children != null) {
 			return children;
 		}
-		
+
 		children = createChildren(tree, prefixMap);
-		
+
 		if (isChildren) {
 			return children;
 		}
-		
+
 		StringBuffer buffer = childrenToString(new StringBuffer(), children);
-		
+
 		return buffer.toString();
 	}
-	
+
 	/**
 	 * Generate a list of property children from a parse tree node
-	 * 
+	 *
 	 * @param tree
 	 * @param prefixMap
-	 * 
+	 *
 	 * @return the resulting property list
 	 */
 	static List<Property>
@@ -108,24 +107,24 @@ public class PropertiesInvocationHandler implements InvocationHandler
 	)
 	{
 		List<Property> children = new ArrayList<Property>(tree.getChildCount());
-		
+
 		for (int index = 0; index < tree.getChildCount(); index++) {
 
 			Tree treeChild = tree.getChild(index);
-			
+
 			Property property;
-			
+
 			switch (treeChild.getType())
 			{
 			case OslcSelectParser.WILDCARD:
 				property = (Property)
-					Proxy.newProxyInstance(Wildcard.class.getClassLoader(), 
+					Proxy.newProxyInstance(Wildcard.class.getClassLoader(),
 							new Class<?>[] { Wildcard.class },
 							new WildcardInvocationHandler());
 				break;
 			case OslcSelectParser.PREFIXED_NAME:
 				property = (Property)
-					Proxy.newProxyInstance(Identifier.class.getClassLoader(), 
+					Proxy.newProxyInstance(Identifier.class.getClassLoader(),
 							new Class<?>[] { Identifier.class },
 							new PropertyInvocationHandler(
 									(CommonTree)treeChild.getChild(0),
@@ -134,27 +133,27 @@ public class PropertiesInvocationHandler implements InvocationHandler
 			default:
 			case OslcSelectParser.NESTED_PROPERTIES:
 				property = (Property)
-					Proxy.newProxyInstance(NestedProperty.class.getClassLoader(), 
+					Proxy.newProxyInstance(NestedProperty.class.getClassLoader(),
 							new Class<?>[] { NestedProperty.class },
 							new NestedPropertyInvocationHandler(treeChild,
 																prefixMap));
 				break;
 			}
-			
+
 			children.add(property);
 		}
-		
+
 		children = Collections.unmodifiableList(children);
-		
+
 		return children;
 	}
-	
+
 	/**
 	 * Generate string representation of a children property list
-	 * 
+	 *
 	 * @param buffer
 	 * @param children
-	 * 
+	 *
 	 * @return the buffer representation of the property list
 	 */
 	static StringBuffer
@@ -164,21 +163,21 @@ public class PropertiesInvocationHandler implements InvocationHandler
 	)
 	{
 		boolean first = true;
-		 
+
 		 for (Property property : children) {
-			 
+
 			 if (first) {
 				 first = false;
 			 } else {
 				 buffer.append(',');
 			 }
-			 
+
 			 buffer.append(property.toString());
 		 }
-		
+
 		 return buffer;
 	}
-	
+
 	private final CommonTree tree;
 	protected final Map<String, String> prefixMap;
 	private List<Property> children = null;

--- a/org.eclipse.lyo.core.query/src/main/java/org/eclipse/lyo/core/query/impl/SortTermsInvocationHandler.java
+++ b/org.eclipse.lyo.core.query/src/main/java/org/eclipse/lyo/core/query/impl/SortTermsInvocationHandler.java
@@ -3,10 +3,10 @@
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
- * and Eclipse Distribution License v. 1.0 which accompanies this distribution. 
+ * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
  *
  * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
- * and the Eclipse Distribution License is available at 
+ * and the Eclipse Distribution License is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
  *
  * Contributors:
@@ -43,7 +43,7 @@ public class SortTermsInvocationHandler implements InvocationHandler
 		this.tree = tree;
 		this.prefixMap = prefixMap;
 	}
-	
+
 	/**
 	 * @see java.lang.reflect.InvocationHandler#invoke(java.lang.Object, java.lang.reflect.Method, java.lang.Object[])
 	 */
@@ -53,29 +53,28 @@ public class SortTermsInvocationHandler implements InvocationHandler
 		Object proxy,
 		Method method,
 		Object[] args
-	) throws Throwable
-	{
+	) {
 		if (children == null) {
-			
+
 			children = new ArrayList<SortTerm>(tree.getChildCount());
-			
+
 			for (int index = 0; index < tree.getChildCount(); index++) {
-				
+
 				Tree child = tree.getChild(index);
-				
+
 				Object simpleTerm;
-				
+
 				switch(child.getType()) {
 				case OslcOrderByParser.SIMPLE_TERM:
-					simpleTerm = 
-						Proxy.newProxyInstance(SimpleSortTerm.class.getClassLoader(), 
+					simpleTerm =
+						Proxy.newProxyInstance(SimpleSortTerm.class.getClassLoader(),
 								new Class<?>[] { SimpleSortTerm.class },
 								new SimpleSortTermInvocationHandler(
 										child, prefixMap));
 					break;
 				case OslcOrderByParser.SCOPED_TERM:
-					simpleTerm = 
-						Proxy.newProxyInstance(ScopedSortTerm.class.getClassLoader(), 
+					simpleTerm =
+						Proxy.newProxyInstance(ScopedSortTerm.class.getClassLoader(),
 								new Class<?>[] { ScopedSortTerm.class },
 								new ScopedSortTermInvocationHandler(
 										child, prefixMap));
@@ -83,31 +82,31 @@ public class SortTermsInvocationHandler implements InvocationHandler
 				default:
 					throw new IllegalStateException("unimplemented type of sort term: " + child.getText());
 				}
-				
+
 				children.add((SortTerm)simpleTerm);
 			}
-			
+
 			children = Collections.unmodifiableList(children);
 		}
-		
-		if (method.getName().equals("children")) {		  
+
+		if (method.getName().equals("children")) {
 			return children;
 		}
-		
+
 		StringBuffer buffer = new StringBuffer();
 		boolean first = true;
-		
+
 		for (SortTerm term : children) {
-			
+
 			if (first) {
 				first = false;
 			} else {
 				buffer.append(',');
 			}
-			
+
 			buffer.append(term.toString());
 		}
-		
+
 		return buffer.toString();
 	}
 

--- a/org.eclipse.lyo.core.trs/src/main/java/org/eclipse/lyo/core/trs/TrackedResourceSet.java
+++ b/org.eclipse.lyo.core.trs/src/main/java/org/eclipse/lyo/core/trs/TrackedResourceSet.java
@@ -82,7 +82,7 @@ public class TrackedResourceSet extends AbstractResource {
     /**
      * @param changeLog the changeLog to set
      */
-    public void setChangeLog(ChangeLog changeLog) throws URISyntaxException {
+    public void setChangeLog(ChangeLog changeLog) {
         // Make sure the About URI of the change log is null since it will
         // become a blank node in the turtle output
         changeLog.setAbout(null);

--- a/org.eclipse.lyo.core.trs/src/test/java/org/eclipse/lyo/core/trs/ChangeLogTest.java
+++ b/org.eclipse.lyo.core.trs/src/test/java/org/eclipse/lyo/core/trs/ChangeLogTest.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 public class ChangeLogTest {
     private final static Logger log = LoggerFactory.getLogger(ChangeLogTest.class);
     @Test
-    public void changeEventListNotNullByDefault() throws Exception {
+    public void changeEventListNotNullByDefault() {
         ChangeLog changeLog = new ChangeLog();
 
         final List<ChangeEvent> changeEventList = changeLog.getChange();
@@ -24,7 +24,7 @@ public class ChangeLogTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void changeEventListCantBeSetToNull() throws Exception {
+    public void changeEventListCantBeSetToNull() {
         ChangeLog changeLog = new ChangeLog();
         log.info("Setting changeLog Change Event list to null");
         changeLog.setChange(null);

--- a/org.eclipse.lyo.core.trs/src/test/java/org/eclipse/lyo/core/trs/TrackedResourceSetTest.java
+++ b/org.eclipse.lyo.core.trs/src/test/java/org/eclipse/lyo/core/trs/TrackedResourceSetTest.java
@@ -67,8 +67,7 @@ public class TrackedResourceSetTest {
                 trsExpected.getChangeLog().getChange().size());
     }
 
-    private TrackedResourceSet aTrsWithChangelog(final ChangeLog changeLog)
-            throws URISyntaxException {
+    private TrackedResourceSet aTrsWithChangelog(final ChangeLog changeLog) {
         final TrackedResourceSet trsExpected = new TrackedResourceSet();
         trsExpected.setBase(URI.create("http://example.com/dummy"));
         trsExpected.setChangeLog(changeLog);

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JConstants.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JConstants.java
@@ -12,7 +12,7 @@
  * Contributors:
  *
  *	   Michael Fiedler		 - initial API and implementation
- *	   
+ *
  *******************************************************************************/
 package org.eclipse.lyo.oslc4j.core;
 
@@ -20,24 +20,36 @@ import java.util.HashMap;
 import java.util.Map;
 
 public interface OSLC4JConstants {
-	
-	public static final String OSLC4J_PUBLIC_URI		= "org.eclipse.lyo.oslc4j.publicURI";
-	public static final String OSLC4J_DISABLE_HOST_RESOLUTION = "org.eclipse.lyo.oslc4j.disableHostResolution";
-	public static final String OSLC4J_DISABLE_RELATIVE_URIS = "org.eclipse.lyo.oslc4j.disableRelativeURIs";
-	public static final String OSLC4J_USE_BEAN_CLASS_FOR_PARSING = "org.eclipse.lyo.oslc4j.useBeanClassForParsing";
-	public static final String OSLC4J_INFER_TYPE_FROM_SHAPE = "org.eclipse.lyo.oslc4j.inferTypeFromResourceShape";
-	
-	public static final Map<String, Object> OSL4J_PROPERTY_SINGLETON = new HashMap<String, Object>(0);
-	
-	public static final String OSLC4J_SELECTED_PROPERTIES = "org.eclipse.lyo.oslc4j.selected.properties";
-	public static final String OSLC4J_NEXT_PAGE = "org.eclipse.lyo.oslc4j.next.page";
-	public static final String OSLC4J_TOTAL_COUNT = "org.eclipse.lyo.oslc4j.total.count";
-	
-	/**
+
+    String OSLC4J_PUBLIC_URI                 = "org.eclipse.lyo.oslc4j.publicURI";
+    String OSLC4J_DISABLE_HOST_RESOLUTION    = "org.eclipse.lyo.oslc4j.disableHostResolution";
+    String OSLC4J_DISABLE_RELATIVE_URIS      = "org.eclipse.lyo.oslc4j.disableRelativeURIs";
+    String OSLC4J_USE_BEAN_CLASS_FOR_PARSING = "org.eclipse.lyo.oslc4j.useBeanClassForParsing";
+    String OSLC4J_INFER_TYPE_FROM_SHAPE      = "org.eclipse.lyo.oslc4j.inferTypeFromResourceShape";
+
+    Map<String, Object> OSL4J_PROPERTY_SINGLETON = new HashMap<String, Object>(0);
+
+    String OSLC4J_SELECTED_PROPERTIES = "org.eclipse.lyo.oslc4j.selected.properties";
+    String OSLC4J_NEXT_PAGE           = "org.eclipse.lyo.oslc4j.next.page";
+    String OSLC4J_TOTAL_COUNT         = "org.eclipse.lyo.oslc4j.total.count";
+
+    /**
 	 * System property {@value} : When "true", the query result list type will be
 	 * http://www.w3.org/2000/01/rdf-schema#Container, otherwise it will
 	 * have no type. No type is the default.
-	 * 
+     *
 	 */
-	public static final String OSLC4J_QUERY_RESULT_LIST_AS_CONTAINER = "org.eclipse.lyo.oslc4j.queryResultListAsContainer";
+    String OSLC4J_QUERY_RESULT_LIST_AS_CONTAINER = "org.eclipse.lyo.oslc4j.queryResultListAsContainer";
+
+    /**
+     * When "true", always abbreviate RDF/XML, even when asked for application/rdf+xml. Otherwise,
+     * abbreviated RDF/XML is only returned when application/xml is requested. Does not affect
+     * text/turtle responses.
+     */
+    String OSLC4J_ALWAYS_XML_ABBREV = "org.eclipse.lyo.oslc4j" + "" + "" + ".alwaysXMLAbbrev";
+    /**
+     * When "true" (default), fail on when reading a property value that is not a legal instance of
+     * a datatype. When "false", skip over invalid values in extended properties.
+     */
+    String OSLC4J_STRICT_DATATYPES  = "org.eclipse.lyo.oslc4j.strictDatatypes";
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
@@ -33,19 +33,18 @@ import javax.ws.rs.core.UriBuilder;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.namespace.QName;
-import org.eclipse.lyo.oslc4j.core.model.ResourceShape;
-import org.eclipse.lyo.oslc4j.core.model.XMLLiteral;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import org.apache.jena.datatypes.DatatypeFormatException;
 import org.apache.jena.datatypes.RDFDatatype;
 import org.apache.jena.datatypes.TypeMapper;
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.datatypes.xsd.impl.XMLLiteralType;
+import org.apache.jena.ext.com.google.common.base.Strings;
 import org.apache.jena.rdf.model.Property;
+import org.eclipse.lyo.oslc4j.core.model.ResourceShape;
+import org.eclipse.lyo.oslc4j.core.model.XMLLiteral;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class OSLC4JUtils {
@@ -79,7 +78,7 @@ public class OSLC4JUtils {
 	 * 412789.
 	 */
 	private static String inferTypeFromShape = System.getProperty(OSLC4JConstants.OSLC4J_INFER_TYPE_FROM_SHAPE);
-	
+
 	/**
 	 * List of available ResourceShapes. This list will be used to infer the
 	 * property type from the resource shape and it will only be considered if
@@ -87,18 +86,143 @@ public class OSLC4JUtils {
 	 * fix for defect 412789.
 	 */
 	private static List<ResourceShape> shapes = new ArrayList<>();
-	
+
+	public static boolean useStrictDatatypes() {
+		return parseBooleanPropertyOrDefault(OSLC4JConstants.OSLC4J_STRICT_DATATYPES, true);
+	}
+
+	public static boolean alwaysAbbrevXML() {
+		return parseBooleanPropertyOrDefault(OSLC4JConstants.OSLC4J_ALWAYS_XML_ABBREV, false);
+	}
+
+	/**
+	 * Returns the boolean value of org.eclipse.lyo.oslc4j.disableRelativeURIs Default is true if
+	 * not set or invalid (relative URIs will not be allowed)
+	 *
+	 * @return true if relative URIs are disabled, or if the property is not set or invalid.
+	 */
+	public static boolean relativeURIsAreDisabled() {
+		return parseBooleanPropertyOrDefault(OSLC4JConstants.OSLC4J_DISABLE_RELATIVE_URIS, true);
+	}
+
+	/**
+	 * This method receives the property name and the property value and tries to infer the property
+	 * type from the pre-defined list of Resource Shapes. Then returns the corresponding java object
+	 * for the given object value. Returns a null object when it was not possible to infer the
+	 * property type from the list of Resource Shapes.
+	 *
+	 * @param propertyQName Property information
+	 * @param originalValue Property value
+	 *
+	 * @return Java object related to the Resource Shape type.
+	 *
+	 * @throws DatatypeConfigurationException , IllegalArgumentException, InstantiationException,
+	 *                                        InvocationTargetException on
+	 */
+	public static Object getValueBasedOnResourceShapeType(final HashSet<String> rdfTypesList,
+			final QName propertyQName, final Object originalValue)
+			throws DatatypeConfigurationException, IllegalArgumentException, InstantiationException {
+		if (null == rdfTypesList || rdfTypesList.isEmpty() || null == propertyQName || null == originalValue) {
+			return null;
+		}
+		try {
+			// get the pre-defined list of ResourceShapes
+			List<ResourceShape> shapes = OSLC4JUtils.getShapes();
+
+			if (null == shapes || shapes.isEmpty()) {
+				return null;
+			}
+
+			// try to find the attribute type in the list of
+			// resource shapes
+			String propertyName = propertyQName.getNamespaceURI() + propertyQName.getLocalPart();
+
+			TypeMapper typeMapper = TypeMapper.getInstance();
+
+			for (ResourceShape shape : shapes) {
+
+				// ensure that the current resource shape matches the resource rdf:type
+				if (!doesResourceShapeMatchRdfTypes(shape, rdfTypesList)) {
+					continue;
+				}
+
+				org.eclipse.lyo.oslc4j.core.model.Property[] props = shape.getProperties();
+
+				for (org.eclipse.lyo.oslc4j.core.model.Property prop : props) {
+					URI propDefinition = prop.getPropertyDefinition();
+
+					if (!propertyName.equals(propDefinition.toString())) {
+						continue;
+					}
+					URI propValueType = prop.getValueType();
+
+					if (null == propValueType) {
+						continue;
+					}
+
+					RDFDatatype dataTypeFromShape = typeMapper.getTypeByName(propValueType.toString());
+
+					// this is a literal type
+					if (null == dataTypeFromShape) {
+						continue;
+					}
+					try {
+
+						// special treatment for XMLLiteral
+						if (isXmlLiteralProperty(propValueType)) {
+							return xmlLiteralPropertyFrom(originalValue);
+						}
+
+						// special treatment for Date
+						if (isDateProperty(dataTypeFromShape)) {
+							return datePropertyFrom(originalValue);
+						}
+
+						// special treatment for Boolean
+						if (isBooleanProperty(dataTypeFromShape)) {
+							return booleanPropertyFrom(originalValue);
+
+						}
+
+						// special treatment for double
+						if (isDoubleProperty(dataTypeFromShape)) {
+							return doublePropertyFrom(originalValue);
+						}
+
+						// special treatment for float
+						if (isFloatProperty(dataTypeFromShape)) {
+							return floatPropertyFrom(originalValue);
+						}
+						Constructor<?> cons = dataTypeFromShape.getJavaClass()
+															   .getConstructor(String.class);
+						return cons.newInstance(originalValue.toString());
+					} catch (IllegalArgumentException | InvocationTargetException | DatatypeFormatException e) {
+						throw new IllegalArgumentException(e);
+					}
+				}
+			}
+		} catch (NoSuchMethodException | IllegalAccessException e) {
+			// if there is any error while creating the new object, return null,
+			// i.e use the original value and not the new one.
+			// TODO Andrew@2017-07-18: Throw exception instead of returning null
+			log.warn("Could not create extended value <{}> based on shape", propertyQName, e);
+			return null;
+		}
+
+		return null;
+	}
+
 	/**
 	 * Returns the value of org.eclipse.lyo.oslc4j.publicURI or null if not set.
-	 * 
-	 * 
+	 *
+	 *
 	 * @return Public URI, or null if not set
 	 */
 	public static String getPublicURI()
 	{
 		return publicURI;
 	}
-	
+
 	/**
 	 * Sets the value of org.eclipse.lyo.oslc4j.publicURI
 	 * @param newPublicURI
@@ -201,10 +325,16 @@ public class OSLC4JUtils {
 		return useBeanClassForParsing;
 	}
 
-	public static void setUseBeanClassForParsing(String useBeanClassForParsing) {
-		OSLC4JUtils.useBeanClassForParsing = useBeanClassForParsing;
+	/**
+	 * Returns a list of Resource Shapes to be used when inferring a property type from the Resource
+	 * Shape. This method should only be used when the property inferTypeFromShape is set to true.
+	 *
+	 * @return List of Resource Shapes
+	 */
+	public static List<ResourceShape> getShapes() {
+		return shapes;
 	}
-	
+
 	public static boolean inferTypeFromShape() {
 		boolean result = false;
 		if (null != inferTypeFromShape) {
@@ -212,31 +342,16 @@ public class OSLC4JUtils {
 		}
 		return result;
 	}
-	
+
 	public static String getInferTypeFromShape() {
 		return inferTypeFromShape;
-	}
-
-	public static void setInferTypeFromShape(String inferTypeFromShape) {
-		OSLC4JUtils.inferTypeFromShape = inferTypeFromShape;
-	}
-
-	/**
-	 * Returns a list of Resource Shapes to be used when inferring a property
-	 * type from the Resource Shape. This method should only be used when the
-	 * property inferTypeFromShape is set to true.
-	 * 
-	 * @return List of Resource Shapes
-	 */
-	public static List<ResourceShape> getShapes() {
-		return shapes;
 	}
 
 	/**
 	 * Sets a list of Resource Shapes to be used when inferring a property type
 	 * from the Resource Shape. This method should only be used when the
 	 * property inferTypeFromShape is set to true.
-	 * 
+	 *
 	 * @param shapes
 	 *			  List of Resource Shapes
 	 */
@@ -249,19 +364,25 @@ public class OSLC4JUtils {
 	 * Default is false if not set or invalid (hostname resolution will take place)
 	 * @return true if host resolution is disabled, false if not set or invalid
 	 */
-	public static boolean isHostResolutionDisabled()
-	{
-		boolean retVal = false;
-
-		String hostResDisabledProp = System.getProperty(OSLC4JConstants.OSLC4J_DISABLE_HOST_RESOLUTION);
-		if (hostResDisabledProp !=null)
-		{
-			retVal = Boolean.parseBoolean(hostResDisabledProp);
-		}
-		return retVal;
-		
+	public static boolean isHostResolutionDisabled() {
+		return parseBooleanPropertyOrDefault(OSLC4JConstants.OSLC4J_DISABLE_HOST_RESOLUTION, false);
 	}
-	
+
+	/**
+	 * Return if the query result list type will be http://www.w3.org/2000/01/rdf-schema#Container
+	 * or there will be no type. Default is no type.
+	 */
+	public static boolean isQueryResultListAsContainer() {
+		return parseBooleanPropertyOrDefault(OSLC4JConstants.OSLC4J_QUERY_RESULT_LIST_AS_CONTAINER,
+											 false
+		);
+	}
+
+	// TODO Andrew@2018-03-03: we have to deprecate this, and have users go via system properties
+	public static void setUseBeanClassForParsing(String useBeanClassForParsing) {
+		OSLC4JUtils.useBeanClassForParsing = useBeanClassForParsing;
+	}
+
 	public static void setHostResolutionDisabled(boolean hostResDisabled)
 	{
 		System.setProperty(OSLC4JConstants.OSLC4J_DISABLE_HOST_RESOLUTION, Boolean.toString(hostResDisabled));
@@ -406,31 +527,37 @@ public class OSLC4JUtils {
 		return hostName;
 	}
 
-	/**
-	 * Returns the boolean value of org.eclipse.lyo.oslc4j.disableRelativeURIs
-	 * Default is true if not set or invalid (relative URIs will not be allowed)
-	 * @return true if relative URIs are disabled, or if the property is not set or invalid.
-	 */
-	public static boolean relativeURIsAreDisabled()
-	{
-		boolean retVal = true;
-
-		String relURIsDisabledProp = System.getProperty(OSLC4JConstants.OSLC4J_DISABLE_RELATIVE_URIS);
-		if (relURIsDisabledProp !=null)
-		{
-			retVal = Boolean.parseBoolean(relURIsDisabledProp);
-		}
-		return retVal;
+	// TODO Andrew@2018-03-03: we have to deprecate this, and have users go via system properties
+	public static void setInferTypeFromShape(String inferTypeFromShape) {
+		OSLC4JUtils.inferTypeFromShape = inferTypeFromShape;
 	}
 
 	/**
-	 * Return if the query result list type will be
-	 * http://www.w3.org/2000/01/rdf-schema#Container or there will be no type.
-	 * Default is no type.
+	 * @param key          key to get a system property
+	 * @param defaultValue used only if the property is missing
+	 *
+	 * @return boolean value of a property, the default value if it's missing or an
+	 *         IllegalArgumentException if the property value is malformed
 	 */
-	public static boolean isQueryResultListAsContainer()
-	{
-		return "true".equals(System.getProperty(OSLC4JConstants.OSLC4J_QUERY_RESULT_LIST_AS_CONTAINER, "false"));
+	private static Boolean parseBooleanPropertyOrDefault(final String key,
+			final boolean defaultValue) {
+		Boolean value = null;
+		final String property = System.getProperty(key);
+		if (Strings.isNullOrEmpty(property)) {
+			value = defaultValue;
+		} else {
+			try {
+				value = parseBooleanStrict(property.trim());
+			} catch (IllegalArgumentException e) {
+				log.error(
+						"System property '{}' holds illegal value: '{}' (only 'true' or 'false' are allowed)",
+						key,
+						property
+				);
+				throw e;
+			}
+		}
+		return value;
 	}
 
 	/**
@@ -465,120 +592,18 @@ public class OSLC4JUtils {
 	}
 
 	/**
-	 * This method receives the property name and the property value and tries
-	 * to infer the property type from the pre-defined list of Resource Shapes.
-	 * Then returns the corresponding java object for the given object value.
-	 * Returns a null object when it was not possible to infer the property type
-	 * from the list of Resource Shapes.
+	 * Parse a boolean more strictly than Java standard library.
 	 *
-	 * @param rdfTypesList
-	 * @param propertyQName
-	 *			  Property information
-	 * @param originalValue
-	 *			  Property value
-	 * @return Java object related to the Resource Shape type.
-	 * @throws DatatypeConfigurationException
-	 *			   , IllegalArgumentException, InstantiationException,
-	 *			   InvocationTargetException
-	 on 
-	 * 
+	 * @throws IllegalArgumentException if the value cannot be parsed into true or false
 	 */
-	public static Object getValueBasedOnResourceShapeType(final HashSet<String> rdfTypesList,
-			final QName propertyQName, final Object originalValue)
-			throws DatatypeConfigurationException, IllegalArgumentException,
-			InstantiationException,
-			InvocationTargetException {
-		if (null == rdfTypesList || rdfTypesList.isEmpty() || null == propertyQName || null ==
-				originalValue) {
-			return null;
+	private static boolean parseBooleanStrict(final String input) throws IllegalArgumentException {
+		if ("true".equalsIgnoreCase(input)) {
+			return true;
+		} else if ("false".equalsIgnoreCase(input)) {
+			return false;
+		} else {
+			throw new IllegalArgumentException("Value has to be either true or false");
 		}
-		try {
-			// get the pre-defined list of ResourceShapes
-			List<ResourceShape> shapes = OSLC4JUtils.getShapes();
-
-			if (null == shapes || shapes.isEmpty()) {
-				return null;
-			}
-
-			// try to find the attribute type in the list of
-			// resource shapes
-			String propertyName = propertyQName.getNamespaceURI() + propertyQName.getLocalPart();
-
-			TypeMapper typeMapper = TypeMapper.getInstance();
-
-			for (ResourceShape shape : shapes) {
-
-				// ensure that the current resource shape matches the resource rdf:type
-				if (!doesResourceShapeMatchRdfTypes(shape, rdfTypesList)) {
-					continue;
-				}
-
-				org.eclipse.lyo.oslc4j.core.model.Property[] props = shape.getProperties();
-
-				for (org.eclipse.lyo.oslc4j.core.model.Property prop : props) {
-					URI propDefinition = prop.getPropertyDefinition();
-
-					if (!propertyName.equals(propDefinition.toString())) {
-						continue;
-					}
-					URI propValueType = prop.getValueType();
-
-					if (null == propValueType) {
-						continue;
-					}
-
-					RDFDatatype dataTypeFromShape = typeMapper.getTypeByName(
-							propValueType.toString());
-
-					// this is a literal type
-					if (null == dataTypeFromShape) {
-						continue;
-					}
-					try {
-
-						// special treatment for XMLLiteral
-						if (isXmlLiteralProperty(propValueType)) {
-							return xmlLiteralPropertyFrom(originalValue);
-						}
-
-						// special treatment for Date
-						if (isDateProperty(dataTypeFromShape)) {
-							return datePropertyFrom(originalValue);
-						}
-
-						// special treatment for Boolean
-						if (isBooleanProperty(dataTypeFromShape)) {
-							return booleanPropertyFrom(originalValue);
-
-						}
-
-						// special treatment for double
-						if (isDoubleProperty(dataTypeFromShape)) {
-							return doublePropertyFrom(originalValue);
-						}
-
-						// special treatment for float
-						if (isFloatProperty(dataTypeFromShape)) {
-							return floatPropertyFrom(originalValue);
-						}
-						Constructor<?> cons = dataTypeFromShape.getJavaClass().getConstructor(
-								String.class);
-						return cons.newInstance(originalValue.toString());
-					} catch (IllegalArgumentException | InvocationTargetException |
-							DatatypeFormatException e) {
-						throw new IllegalArgumentException(e);
-					}
-				}
-			}
-		} catch (NoSuchMethodException | IllegalAccessException e) {
-			// if there is any error while creating the new object, return null,
-			// i.e use the original value and not the new one.
-			// TODO Andrew@2017-07-18: Throw exception instead of returning null
-			log.warn("Could not create extended value <{}> based on shape", propertyQName, e);
-			return null;
-		}
-
-		return null;
 	}
 
 	private static Object floatPropertyFrom(final Object originalValue) {

--- a/org.eclipse.lyo.oslc4j.core/src/test/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtilsTest.java
+++ b/org.eclipse.lyo.oslc4j.core/src/test/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtilsTest.java
@@ -79,7 +79,7 @@ public class OSLC4JUtilsTest {
     }
 
     @Test
-    public void resolveFullPathUriWithoutPublicUri() throws Exception {
+    public void resolveFullPathUriWithoutPublicUri() {
         final HttpServletRequest request = mockRequest();
 
         final String fullUri = OSLC4JUtils.resolveFullUri(request);
@@ -100,7 +100,7 @@ public class OSLC4JUtilsTest {
     }
 
     @Test
-    public void resolveServletUriWithoutPublicUri() throws Exception {
+    public void resolveServletUriWithoutPublicUri() {
         final HttpServletRequest request = mockRequest();
 
         final String fullUri = OSLC4JUtils.resolveServletUri(request);

--- a/org.eclipse.lyo.oslc4j.core/src/test/java/org/eclipse/lyo/oslc4j/core/model/LinkTest.java
+++ b/org.eclipse.lyo.oslc4j.core/src/test/java/org/eclipse/lyo/oslc4j/core/model/LinkTest.java
@@ -32,7 +32,7 @@ public class LinkTest {
     private static final String LABEL_B = "Example label B";
 
     @Test
-    public void testEqualsWorksOnIdenticalValues() throws Exception {
+    public void testEqualsWorksOnIdenticalValues() {
         String label = "Example label";
 
         // use new String to force unequal references
@@ -43,7 +43,7 @@ public class LinkTest {
     }
 
     @Test
-    public void testEqualsWorksOnDifferentLabels() throws Exception {
+    public void testEqualsWorksOnDifferentLabels() {
         // use new String to force unequal references
         Link linkA = new Link(URI.create(URI_A), new String(LABEL_A));
         Link linkB = new Link(URI.create(URI_A), new String(LABEL_B));
@@ -52,7 +52,7 @@ public class LinkTest {
     }
 
     @Test
-    public void testEqualsWorksInHashSet() throws Exception {
+    public void testEqualsWorksInHashSet() {
 
         Set<Link> setA = new HashSet<Link>() {{
             this.add(new Link(URI.create(URI_A), LABEL_A));
@@ -68,7 +68,7 @@ public class LinkTest {
     }
 
     @Test
-    public void testEqualsWorksInHashSetWhenDifferent() throws Exception {
+    public void testEqualsWorksInHashSetWhenDifferent() {
 
         Set<Link> setA = new HashSet<Link>() {{
             this.add(new Link(URI.create(URI_A), LABEL_A));
@@ -83,7 +83,7 @@ public class LinkTest {
     }
 
     @Test
-    public void testHashCodeSameEquals() throws Exception {
+    public void testHashCodeSameEquals() {
         Link linkA = new Link(URI.create(URI_A), new String(LABEL_A));
         Link linkB = new Link(URI.create(URI_A), new String(LABEL_A));
 
@@ -91,7 +91,7 @@ public class LinkTest {
     }
 
     @Test
-    public void testHashCodeDiffers() throws Exception {
+    public void testHashCodeDiffers() {
         Link linkA = new Link(URI.create(URI_A), new String(LABEL_A));
         Link linkB = new Link(URI.create(URI_B), new String(LABEL_A));
 
@@ -99,7 +99,7 @@ public class LinkTest {
     }
 
     @Test
-    public void testHashCodeIsTheSameForDifferentLabels() throws Exception {
+    public void testHashCodeIsTheSameForDifferentLabels() {
         Link linkA = new Link(URI.create(URI_A), new String(LABEL_A));
         Link linkB = new Link(URI.create(URI_A), new String(LABEL_B));
 

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelper.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelper.java
@@ -1083,7 +1083,7 @@ public final class JenaModelHelper
 				String rawValue = literal.getString();
 				String datatype = literal.getDatatypeURI();
 
-				if ("false".equals(System.getProperty(AbstractOslcRdfXmlProvider.OSLC4J_STRICT_DATATYPES)))
+				if (!OSLC4JUtils.useStrictDatatypes())
 			   	{
 					if (logger.isWarnEnabled())
 					{
@@ -1153,6 +1153,7 @@ public final class JenaModelHelper
 			return nestedResourceURI;
 		}
 	}
+
 
 	private static Map<String, Method> createPropertyDefinitionToSetMethods(final Class<?> beanClass)
 			throws OslcCoreApplicationException
@@ -2031,9 +2032,9 @@ public final class JenaModelHelper
 					  model,
 					  reifiedStatement,
 					  nestedProperties);
-	
+
 		//https://bugs.eclipse.org/bugs/show_bug.cgi?id=526188
-		//If the resulting reifiedStatement only contain the 4 statements about its subject, predicate object, & type, 
+		//If the resulting reifiedStatement only contain the 4 statements about its subject, predicate object, & type,
 		//then there are no additional statements on the statement. Hence, remove the newly created reifiedStatement.
 		if (reifiedStatement.listProperties().toList().size() == 4) {
 			reifiedStatement.removeProperties();

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcCompactRdfProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcCompactRdfProvider.java
@@ -80,8 +80,7 @@ public final class OslcCompactRdfProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		writeTo(false,
 				new Compact[] {compact},
@@ -109,8 +108,7 @@ public final class OslcCompactRdfProvider
 							final MediaType						 mediaType,
 							final MultivaluedMap<String, String> map,
 							final InputStream					 inputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		final Object[] objects = readFrom(type,
 										  OslcMediaType.APPLICATION_XML_TYPE,

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlArrayProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlArrayProvider.java
@@ -71,7 +71,7 @@ public class OslcRdfXmlArrayProvider
 							mediaType,
 							OslcMediaType.APPLICATION_RDF_XML_TYPE,
 							OslcMediaType.APPLICATION_XML_TYPE,
-							OslcMediaType.TEXT_XML_TYPE, 
+							OslcMediaType.TEXT_XML_TYPE,
 							OslcMediaType.TEXT_TURTLE_TYPE));
 	}
 
@@ -83,12 +83,12 @@ public class OslcRdfXmlArrayProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		OslcNotQueryResult notQueryResult = type.getComponentType().getAnnotation(OslcNotQueryResult.class);
-		
-		writeTo(notQueryResult != null && notQueryResult.value() ? false : true,
+		final boolean queryResult = notQueryResult == null || !notQueryResult.value();
+		writeTo(
+				queryResult,
 				objects,
 				mediaType,
 				map,
@@ -106,7 +106,7 @@ public class OslcRdfXmlArrayProvider
 						   mediaType,
 						   OslcMediaType.APPLICATION_RDF_XML_TYPE,
 						   OslcMediaType.APPLICATION_XML_TYPE,
-						   OslcMediaType.TEXT_XML_TYPE, 
+						   OslcMediaType.TEXT_XML_TYPE,
 						   OslcMediaType.TEXT_TURTLE_TYPE));
 	}
 
@@ -117,8 +117,7 @@ public class OslcRdfXmlArrayProvider
 							 final MediaType					  mediaType,
 							 final MultivaluedMap<String, String> map,
 							 final InputStream					  inputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		return readFrom(type.getComponentType(),
 						mediaType,

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlCollectionProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlCollectionProvider.java
@@ -100,7 +100,7 @@ public class OslcRdfXmlCollectionProvider
 									   mediaType,
 									   OslcMediaType.APPLICATION_RDF_XML_TYPE,
 									   OslcMediaType.APPLICATION_XML_TYPE,
-									   OslcMediaType.TEXT_XML_TYPE, 
+									   OslcMediaType.TEXT_XML_TYPE,
 									   OslcMediaType.TEXT_TURTLE_TYPE);
 				}
 			}
@@ -117,13 +117,12 @@ public class OslcRdfXmlCollectionProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		final ParameterizedType parameterizedType = (ParameterizedType) genericType;
 		final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
 		OslcNotQueryResult notQueryResult = ((Class<?>)actualTypeArguments[0]).getAnnotation(OslcNotQueryResult.class);
-		
+
 		writeTo(notQueryResult != null && notQueryResult.value() ? false : true,
 				collection.toArray(new Object[collection.size()]),
 				mediaType,
@@ -148,7 +147,7 @@ public class OslcRdfXmlCollectionProvider
 			{
 				final Type actualTypeArgument = actualTypeArguments[0];
 
-				if (URI.class.equals((Class<?>) actualTypeArgument)) 
+				if (URI.class.equals((Class<?>) actualTypeArgument))
 				{
 					if (isCompatible(mediaType,
 							OslcMediaType.APPLICATION_RDF_XML_TYPE,
@@ -157,8 +156,8 @@ public class OslcRdfXmlCollectionProvider
 							OslcMediaType.TEXT_TURTLE_TYPE))
 					{
 						return true;
-					}					 
-				} 
+					}
+				}
 				else if (actualTypeArgument instanceof Class)
 				{
 					return isReadable((Class<?>) actualTypeArgument,
@@ -181,8 +180,7 @@ public class OslcRdfXmlCollectionProvider
 									   final MediaType						mediaType,
 									   final MultivaluedMap<String, String> map,
 									   final InputStream					inputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		if (genericType instanceof ParameterizedType)
 		{

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlProvider.java
@@ -77,18 +77,18 @@ public class OslcRdfXmlProvider
 							   final MediaType	  mediaType)
 	{
 		Class<?> actualType;
-		
+
 		if (FilteredResource.class.isAssignableFrom(type) &&
 			(genericType instanceof ParameterizedType))
 		{
 			ParameterizedType parameterizedType = (ParameterizedType)genericType;
 			Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-			
+
 			if (actualTypeArguments.length != 1)
 			{
 				return false;
 			}
-			
+
 			if (actualTypeArguments[0] instanceof Class<?>)
 			{
 				actualType = (Class<?>)actualTypeArguments[0];
@@ -97,13 +97,13 @@ public class OslcRdfXmlProvider
 			{
 				parameterizedType = (ParameterizedType)actualTypeArguments[0];
 				actualTypeArguments = parameterizedType.getActualTypeArguments();
-				
+
 				if (actualTypeArguments.length != 1 ||
 					! (actualTypeArguments[0] instanceof Class<?>))
 				{
 					return false;
 				}
-				
+
 				actualType = (Class<?>)actualTypeArguments[0];
 			}
 			else if (actualTypeArguments[0] instanceof GenericArrayType)
@@ -111,12 +111,12 @@ public class OslcRdfXmlProvider
 				GenericArrayType genericArrayType =
 					(GenericArrayType)actualTypeArguments[0];
 				Type componentType = genericArrayType.getGenericComponentType();
-				
+
 				if (! (componentType instanceof Class<?>))
 				{
 					return false;
 				}
-				
+
 				actualType = (Class<?>)componentType;
 			}
 			else
@@ -129,13 +129,13 @@ public class OslcRdfXmlProvider
 					&& (ResponseInfoCollection.class.equals(rawType) || ResponseInfoArray.class.equals(rawType)))
 			{
 				return true;
-			}			   
+			}
 		}
 		else
 		{
 			actualType = type;
 		}
-		
+
 		return isWriteable(actualType,
 						   annotations,
 						   mediaType,
@@ -153,51 +153,50 @@ public class OslcRdfXmlProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		Object[]						objects;
 		Map<String, Object>				properties = null;
 		String							descriptionURI = null;
 		String							responseInfoURI = null;
 		ResponseInfo<?>					responseInfo = null;
-		
+
 		if (object instanceof FilteredResource<?>)
 		{
 			final FilteredResource<?> filteredResource =
 				(FilteredResource<?>)object;
-			
+
 			properties = filteredResource.properties();
-			
+
 			if (filteredResource instanceof ResponseInfo<?>)
 			{
 				responseInfo = (ResponseInfo<?>)filteredResource;
-				
+
 				String requestURI = OSLC4JUtils.resolveURI(httpServletRequest, true);
 				responseInfoURI = requestURI;
-				
+
 				FilteredResource<?> container = responseInfo.getContainer();
 				if (container != null)
 				{
 					URI containerAboutURI = container.getAbout();
-					if (containerAboutURI != null) 
+					if (containerAboutURI != null)
 					{
 						descriptionURI = containerAboutURI.toString();
 					}
-				}				 
+				}
 				if (null == descriptionURI)
 				{
 					descriptionURI = requestURI;
 				}
-				
+
 				final String queryString = httpServletRequest.getQueryString();
-				
+
 				if ((queryString != null) &&
 					(isOslcQuery(queryString)))
 				{
 					responseInfoURI += "?" + queryString;
 				}
-				
+
 				if (filteredResource instanceof ResponseInfoArray<?>)
 				{
 					objects = ((ResponseInfoArray<?>)filteredResource).array();
@@ -206,14 +205,14 @@ public class OslcRdfXmlProvider
 				{
 					Collection<?> collection =
 						((ResponseInfoCollection<?>)filteredResource).collection();
-					
+
 					objects = collection.toArray(new Object[collection.size()]);
 				}
 			}
 			else
 			{
 				Object nestedObject = filteredResource.resource();
-				
+
 				if (nestedObject instanceof Object[])
 				{
 					objects = (Object[])nestedObject;
@@ -232,7 +231,7 @@ public class OslcRdfXmlProvider
 		{
 			objects = new Object[] { object };
 		}
-		
+
 		writeTo(objects,
 				mediaType,
 				map,
@@ -253,7 +252,7 @@ public class OslcRdfXmlProvider
 						  mediaType,
 						  OslcMediaType.APPLICATION_RDF_XML_TYPE,
 						  OslcMediaType.APPLICATION_XML_TYPE,
-						  OslcMediaType.TEXT_XML_TYPE, 
+						  OslcMediaType.TEXT_XML_TYPE,
 						  OslcMediaType.TEXT_TURTLE_TYPE);
 	}
 
@@ -278,8 +277,8 @@ public class OslcRdfXmlProvider
 			// Fix for defect 412755
 			if (OSLC4JUtils.useBeanClassForParsing() && objects.length > 1) {
 				throw new IOException("Object length should not be greater than 1.");
-			} 
-			
+			}
+
 			return objects[0];
 		}
 

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcSimpleRdfXmlArrayProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcSimpleRdfXmlArrayProvider.java
@@ -51,8 +51,7 @@ public class OslcSimpleRdfXmlArrayProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		writeTo(objects,
 				mediaType,

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcSimpleRdfXmlCollectionProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcSimpleRdfXmlCollectionProvider.java
@@ -52,8 +52,7 @@ public class OslcSimpleRdfXmlCollectionProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		writeTo(collection.toArray(new Object[collection.size()]),
 				mediaType,

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/RdfXmlAbbreviatedWriterTest.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/RdfXmlAbbreviatedWriterTest.java
@@ -62,7 +62,7 @@ public class RdfXmlAbbreviatedWriterTest {
 		RdfXmlAbbreviatedWriter w = new RdfXmlAbbreviatedWriter();
 		w.write(m, System.out, null);
 	}
-	
+
 	/**
 	 * Scenario tested with cyclic reference http://server/oslc/pr/collection:
 	 * {@code
@@ -86,12 +86,12 @@ public class RdfXmlAbbreviatedWriterTest {
 	 * }
 	 */
 	@Test
-	public void testSelfCircularReference() throws WebApplicationException, IOException, SecurityException,
+	public void testSelfCircularReference() throws WebApplicationException, SecurityException,
 			NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
-		
+
 		// Cannot read a payload with this scenario because the reader will define
 		// the collection as an inline resource, preventing the bug we want to test.
-		
+
 		ServiceProvider sp = new ServiceProvider();
 		sp.setAbout(URI.create("http://test:9999/inlineResources/self-circular.xml"));
 		Service service = new Service();
@@ -107,21 +107,21 @@ public class RdfXmlAbbreviatedWriterTest {
 				(String) null);
 		info.setAbout(URI.create("http://server/pr/collection?oslc.select=*"));
 		info.getContainer().setAbout(URI.create("http://server/pr/collection"));
-		
+
 		// Since we do not have a Mock API, creating a proxy to mock the
 		// request.
 		HttpServletRequest proxy = (HttpServletRequest) Proxy.newProxyInstance(
 				HttpServletRequest.class.getClassLoader(), new Class<?>[] { HttpServletRequest.class },
 				new InvocationHandler() {
 					@Override
-					public Object invoke(Object arg0, Method arg1, Object[] arg2) throws Throwable {
+					public Object invoke(Object arg0, Method arg1, Object[] arg2) {
 						if (arg1.getReturnType().isPrimitive()) {
 							return 0;
 						}
 						return null;
 					}
 				});
-		
+
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		OslcRdfXmlProvider op = new OslcRdfXmlProvider();
 		Field requestURIField = AbstractOslcRdfXmlProvider.class.getDeclaredField("httpServletRequest");
@@ -151,7 +151,7 @@ public class RdfXmlAbbreviatedWriterTest {
 		System.out.println(baos.toString());
 
 		OslcRdfXmlCollectionProvider ocp = new OslcRdfXmlCollectionProvider();
-		
+
 		@SuppressWarnings({"rawtypes", "unchecked"}) // The warning for (Class)List.class can't be resolved in the code but will work at run time.
 		Collection col = ocp.readFrom((Class)List.class, paramType, null, MediaType.APPLICATION_XML_TYPE, null,
 				new ByteArrayInputStream(baos.toByteArray()));
@@ -159,5 +159,5 @@ public class RdfXmlAbbreviatedWriterTest {
 		Assert.assertEquals("Unable to read a collection with cyclic reference", 1, col.size());
 
 	}
-	
+
 }

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/UnparseableLiteralTest.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/UnparseableLiteralTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 
 import javax.xml.namespace.QName;
 
+import org.eclipse.lyo.oslc4j.core.OSLC4JConstants;
 import org.eclipse.lyo.oslc4j.core.UnparseableLiteral;
 import org.eclipse.lyo.oslc4j.provider.jena.AbstractOslcRdfXmlProvider;
 import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
@@ -42,12 +43,12 @@ import org.apache.jena.vocabulary.DCTerms;
 public class UnparseableLiteralTest {
 	@Before
 	public void before() {
-		System.setProperty(AbstractOslcRdfXmlProvider.OSLC4J_STRICT_DATATYPES, "false");
+		System.setProperty(OSLC4JConstants.OSLC4J_STRICT_DATATYPES, "false");
 	}
 
 	@After
 	public void after() {
-		System.getProperties().remove(AbstractOslcRdfXmlProvider.OSLC4J_STRICT_DATATYPES);
+		System.getProperties().remove(OSLC4JConstants.OSLC4J_STRICT_DATATYPES);
 	}
 
 	@Test

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/resources/ResourceWithReifiedLinks.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/resources/ResourceWithReifiedLinks.java
@@ -22,17 +22,15 @@ public class ResourceWithReifiedLinks extends AbstractResource
     private String title;
     private Link linkWithNoLabel = new Link();
     private Link linkWithLabel = new Link();
-    
-    public ResourceWithReifiedLinks() throws URISyntaxException
-    {
+
+    public ResourceWithReifiedLinks() {
         super();
     }
-    
-    public ResourceWithReifiedLinks(final URI about) throws URISyntaxException
-    {
+
+    public ResourceWithReifiedLinks(final URI about) {
         super(about);
     }
-    
+
     @OslcName("linkWithNoLabel")
     @OslcPropertyDefinition(TEST_NAMESPACE + "linkWithNoLabel")
     @OslcValueType(ValueType.Resource)

--- a/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcCompactJsonProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcCompactJsonProvider.java
@@ -80,8 +80,7 @@ public final class OslcCompactJsonProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		writeTo(false,
 				new Compact[] {compact},
@@ -109,8 +108,7 @@ public final class OslcCompactJsonProvider
 							final MediaType						 mediaType,
 							final MultivaluedMap<String, String> map,
 							final InputStream					 inputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		final Object[] objects = readFrom(type,
 										  OslcMediaType.APPLICATION_JSON_TYPE,

--- a/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonArrayProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonArrayProvider.java
@@ -79,8 +79,7 @@ public class OslcRdfJsonArrayProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		writeTo(true,
 				objects,
@@ -108,8 +107,7 @@ public class OslcRdfJsonArrayProvider
 							 final MediaType					  mediaType,
 							 final MultivaluedMap<String, String> map,
 							 final InputStream					  inputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		return readFrom(type.getComponentType(),
 						mediaType,

--- a/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonCollectionProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonCollectionProvider.java
@@ -113,8 +113,7 @@ public class OslcRdfJsonCollectionProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		writeTo(true,
 				collection.toArray(new Object[collection.size()]),
@@ -141,11 +140,11 @@ public class OslcRdfJsonCollectionProvider
 				final Type actualTypeArgument = actualTypeArguments[0];
 
 				if (URI.class.equals((Class<?>) actualTypeArgument)
-						&& (OslcMediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType))) 
+						&& (OslcMediaType.APPLICATION_JSON_TYPE.isCompatible(mediaType)))
 				{
 					return true;
 				}
-				else 
+				else
 				{
 					return isReadable((Class<?>) actualTypeArgument,
 									  OslcMediaType.APPLICATION_JSON_TYPE,
@@ -164,8 +163,7 @@ public class OslcRdfJsonCollectionProvider
 									   final MediaType						mediaType,
 									   final MultivaluedMap<String, String> map,
 									   final InputStream					inputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		if (genericType instanceof ParameterizedType)
 		{

--- a/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcRdfJsonProvider.java
@@ -77,18 +77,18 @@ public final class OslcRdfJsonProvider
 							   final MediaType	  mediaType)
 	{
 		Class<?> actualType;
-		
+
 		if (FilteredResource.class.isAssignableFrom(type) &&
 			(genericType instanceof ParameterizedType))
 		{
 			ParameterizedType parameterizedType = (ParameterizedType)genericType;
 			Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-			
+
 			if (actualTypeArguments.length != 1)
 			{
 				return false;
 			}
-			
+
 			if (actualTypeArguments[0] instanceof Class<?>)
 			{
 				actualType = (Class<?>)actualTypeArguments[0];
@@ -97,13 +97,13 @@ public final class OslcRdfJsonProvider
 			{
 				parameterizedType = (ParameterizedType)actualTypeArguments[0];
 				actualTypeArguments = parameterizedType.getActualTypeArguments();
-				
+
 				if (actualTypeArguments.length != 1 ||
 					! (actualTypeArguments[0] instanceof Class<?>))
 				{
 					return false;
 				}
-				
+
 				actualType = (Class<?>)actualTypeArguments[0];
 			}
 			else if (actualTypeArguments[0] instanceof GenericArrayType)
@@ -111,12 +111,12 @@ public final class OslcRdfJsonProvider
 				GenericArrayType genericArrayType =
 					(GenericArrayType)actualTypeArguments[0];
 				Type componentType = genericArrayType.getGenericComponentType();
-				
+
 				if (! (componentType instanceof Class<?>))
 				{
 					return false;
 				}
-				
+
 				actualType = (Class<?>)componentType;
 			}
 			else
@@ -129,13 +129,13 @@ public final class OslcRdfJsonProvider
 					&& (ResponseInfoCollection.class.equals(rawType) || ResponseInfoArray.class.equals(rawType)))
 			{
 				return true;
-			}			 
+			}
 		}
 		else
 		{
 			actualType = type;
 		}
-		
+
 		return isWriteable(actualType,
 						   annotations,
 						   OslcMediaType.APPLICATION_JSON_TYPE,
@@ -150,51 +150,50 @@ public final class OslcRdfJsonProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		Object[]						objects;
 		Map<String, Object>				properties = null;
 		String							descriptionURI = null;
 		String							responseInfoURI = null;
 		ResponseInfo<?>					responseInfo = null;
-		
+
 		if (object instanceof FilteredResource<?>)
 		{
 			final FilteredResource<?> filteredResource =
 				(FilteredResource<?>)object;
-			
+
 			properties = filteredResource.properties();
-			
+
 			if (filteredResource instanceof ResponseInfo<?>)
-			{				 
+			{
 				responseInfo = (ResponseInfo<?>)filteredResource;
-				
+
 				String requestURI = OSLC4JUtils.resolveURI(httpServletRequest, true);
 				responseInfoURI = requestURI;
-				
+
 				FilteredResource<?> container = responseInfo.getContainer();
 				if (container != null)
 				{
 					URI containerAboutURI = container.getAbout();
-					if (containerAboutURI != null) 
+					if (containerAboutURI != null)
 					{
 						descriptionURI = containerAboutURI.toString();
 					}
-				}				 
+				}
 				if (null == descriptionURI)
 				{
 					descriptionURI = requestURI;
 				}
-				
+
 				final String queryString = httpServletRequest.getQueryString();
-				
+
 				if ((queryString != null) &&
 					(isOslcQuery(queryString)))
 				{
 					responseInfoURI += "?" + queryString;
 				}
-				
+
 				if (filteredResource instanceof ResponseInfoArray<?>)
 				{
 					objects = ((ResponseInfoArray<?>)filteredResource).array();
@@ -203,14 +202,14 @@ public final class OslcRdfJsonProvider
 				{
 					Collection<?> collection =
 						((ResponseInfoCollection<?>)filteredResource).collection();
-					
+
 					objects = collection.toArray(new Object[collection.size()]);
 				}
 			}
 			else
 			{
 				Object nestedObject = filteredResource.resource();
-				
+
 				if (nestedObject instanceof Object[])
 				{
 					objects = (Object[])nestedObject;
@@ -229,7 +228,7 @@ public final class OslcRdfJsonProvider
 		{
 			objects = new Object[] { object };
 		}
-		
+
 		writeTo(objects,
 				mediaType,
 				map,
@@ -258,8 +257,7 @@ public final class OslcRdfJsonProvider
 						   final MediaType						mediaType,
 						   final MultivaluedMap<String, String> map,
 						   final InputStream					inputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		final Object[] objects = readFrom(type,
 										  mediaType,

--- a/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcSimpleRdfJsonArrayProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcSimpleRdfJsonArrayProvider.java
@@ -51,8 +51,7 @@ public final class OslcSimpleRdfJsonArrayProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		writeTo(objects,
 				mediaType,

--- a/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcSimpleRdfJsonCollectionProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/src/main/java/org/eclipse/lyo/oslc4j/provider/json4j/OslcSimpleRdfJsonCollectionProvider.java
@@ -52,8 +52,7 @@ public final class OslcSimpleRdfJsonCollectionProvider
 						final MediaType						 mediaType,
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
-		   throws IOException,
-				  WebApplicationException
+		   throws WebApplicationException
 	{
 		writeTo(collection.toArray(new Object[collection.size()]),
 				mediaType,

--- a/org.eclipse.lyo.oslc4j.provider.json4j/src/test/java/org/eclipse/lyo/oslc4j/provider/json4j/test/JsonOslcNameTest.java
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/src/test/java/org/eclipse/lyo/oslc4j/provider/json4j/test/JsonOslcNameTest.java
@@ -41,9 +41,9 @@ import org.junit.Test;
 
 /**
  * Tests Json working with different combinations of OslcName annotation.
- * 
+ *
  * @author Fabio Negrello
- * 
+ *
  */
 public class JsonOslcNameTest {
 
@@ -55,7 +55,7 @@ public class JsonOslcNameTest {
 	/**
 	 * Checks that OslcName annotation with empty string does not add RDF type
 	 * to the resource.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -68,7 +68,7 @@ public class JsonOslcNameTest {
 	}
 
 	private JSONObject getJSONObject(Object resource, final OslcRdfJsonProvider oslcRdfJsonProvider)
-			throws IOException, WebApplicationException, JSONException {
+			throws WebApplicationException, JSONException {
 		ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
 		oslcRdfJsonProvider.writeTo(resource, resource.getClass(), resource.getClass(), new Annotation[0],
 				MediaType.APPLICATION_JSON_TYPE, null, outputStream);
@@ -80,7 +80,7 @@ public class JsonOslcNameTest {
 	/**
 	 * Checks that OslcName annotation with empty string does not add default
 	 * RDF type to the resource but adds the ones specified by addTypes method.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -97,7 +97,7 @@ public class JsonOslcNameTest {
 
 	/**
 	 * Checks that OslcName annotation adds RDF type to the resource.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -113,7 +113,7 @@ public class JsonOslcNameTest {
 	/**
 	 * Checks that the absence of OslcName annotation adds default RDF type to
 	 * the resource.
-	 * 
+	 *
 	 * @throws Exception
 	 */
 	@Test
@@ -128,7 +128,7 @@ public class JsonOslcNameTest {
 		verifyRDFTypes(new String[] { typeToAdd, TestResource.TEST_NAMESPACE + "UnnamedResource" }, rdfTypes);
 	}
 
-	private void verifyRDFTypes(String[] expectedRDFTypes, JSONArray rdfTypes) throws JSONException {
+	private void verifyRDFTypes(String[] expectedRDFTypes, JSONArray rdfTypes) {
 		List<String> actualRdfTypesList = new ArrayList<String>();
 		for (Object node : rdfTypes) {
 			OrderedJSONObject obj = (OrderedJSONObject) node;
@@ -143,7 +143,7 @@ public class JsonOslcNameTest {
 
 	/**
 	 * Creates a new instance adding some test values.
-	 * 
+	 *
 	 * @param resource
 	 *			  class.
 	 * @return new instance

--- a/org.eclipse.lyo.oslc4j.provider.json4j/src/test/java/org/eclipse/lyo/oslc4j/provider/json4j/test/TestInvalidTypesJson.java
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/src/test/java/org/eclipse/lyo/oslc4j/provider/json4j/test/TestInvalidTypesJson.java
@@ -29,8 +29,7 @@ public class TestInvalidTypesJson
 {
 	@Test(expected = WebApplicationException.class)
 	public void testInvalidJavaAboutRelativeURI()
-		   throws IOException,
-				  URISyntaxException
+		   throws URISyntaxException
 	{
 		final TestResource relativeUri = new TestResource();
 

--- a/org.eclipse.lyo.oslc4j.wink/src/main/java/org/eclipse/lyo/oslc4j/application/OslcWinkApplication.java
+++ b/org.eclipse.lyo.oslc4j.wink/src/main/java/org/eclipse/lyo/oslc4j/application/OslcWinkApplication.java
@@ -4,7 +4,7 @@
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * and Eclipse Distribution License v. 1.0 which accompanies this distribution.
- *	
+ *
  * The Eclipse Public License is available at http://www.eclipse.org/legal/epl-v10.html
  * and the Eclipse Distribution License is available at
  * http://www.eclipse.org/org/documents/edl-v10.php.
@@ -60,12 +60,11 @@ public abstract class OslcWinkApplication
 
 		this.resourceClasses = resourceClasses;
 	}
-	
+
 	//Bugzilla 392780
 	// Called by OslcDynamicWinkApplication
 	public OslcWinkApplication(final Set<Class<?>> resourceClasses,
-			final String resourceShapesPath)
-			throws OslcCoreApplicationException, URISyntaxException {
+			final String resourceShapesPath) {
 		super();
 
 		this.resourceClasses = resourceClasses;


### PR DESCRIPTION
I also took an opportunity to do refactoring on the abstract provider,
which then went onto other provider and finally ended up in core:

* Remove redundant (not thrown) exceptions (recursively)
* Extract system properties from Jena Provider to OSLCConstants and
  create getters in OSLC4JUtils for consistency
* Refactor OSLC4JUtils to handle booleans better
* Refactor RDF Provider to isolate OSLC Query specific logic
