### PR TITLE
New UniversalResourceSingleProvider to support more RDF formats

### DIFF
--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/OslcMediaType.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/OslcMediaType.java
@@ -18,39 +18,58 @@
  *******************************************************************************/
 package org.eclipse.lyo.oslc4j.core.model;
 
+import javax.print.attribute.standard.Media;
 import javax.ws.rs.core.MediaType;
 
 public interface OslcMediaType {
 
-	public final static String APPLICATION = "application";
-	public final static String TEXT = "text";
+    String    APPLICATION_RDF_XML      = "application/rdf+xml";
+    MediaType APPLICATION_RDF_XML_TYPE = MediaType.valueOf(APPLICATION_RDF_XML);
 
-	public final static String RDF_XML = "rdf+xml";
-	public final static String APPLICATION_RDF_XML = APPLICATION + "/" + RDF_XML;
-	public final static MediaType APPLICATION_RDF_XML_TYPE = new MediaType(APPLICATION, RDF_XML);
+    String    APPLICATION_JSON_LD      = "application/ld+json";
+    MediaType APPLICATION_JSON_LD_TYPE = MediaType.valueOf(APPLICATION_JSON_LD);
 
-	public final static String JSON_LD = "ld+json";
-	public final static String APPLICATION_JSON_LD = APPLICATION + "/" + JSON_LD;
-	public final static MediaType APPLICATION_JSON_LD_TYPE = new MediaType(APPLICATION, JSON_LD);
+    String    TEXT_TURTLE      = "text/turtle";
+    MediaType TEXT_TURTLE_TYPE = MediaType.valueOf(TEXT_TURTLE);
 
-	public final static String APPLICATION_JSON = MediaType.APPLICATION_JSON;
-	public final static MediaType APPLICATION_JSON_TYPE = MediaType.APPLICATION_JSON_TYPE;
+    String    RDF_JSON_MIME = "application/rdf+json";
+    MediaType RDF_JSON_MT   = MediaType.valueOf(RDF_JSON_MIME);
 
-	public final static String APPLICATION_XML = MediaType.APPLICATION_XML;
-	public final static MediaType APPLICATION_XML_TYPE = MediaType.APPLICATION_XML_TYPE;
+    String N_TRIPLES_MIME = "application/n-triples";
+    MediaType N_TRIPLES_MT = MediaType.valueOf(N_TRIPLES_MIME);
 
-	public final static String TEXT_XML = MediaType.TEXT_XML;
-	public final static MediaType TEXT_XML_TYPE = MediaType.TEXT_XML_TYPE;
+    // OSLC specific serialisations
 
-	public final static String TURTLE="turtle";
-	public final static String TEXT_TURTLE = TEXT + "/" + TURTLE;
-	public final static MediaType TEXT_TURTLE_TYPE = new MediaType(TEXT, TURTLE);
+    String    APPLICATION_X_OSLC_COMPACT_XML      = "application" + "/" + "x-oslc-compact+xml";
+    MediaType APPLICATION_X_OSLC_COMPACT_XML_TYPE = new MediaType("application",
+                                                                  "x-oslc-compact+xml");
 
-	public final static String X_OSLC_COMPACT_XML = "x-oslc-compact+xml";
-	public final static String APPLICATION_X_OSLC_COMPACT_XML = APPLICATION + "/" + X_OSLC_COMPACT_XML;
-	public final static MediaType APPLICATION_X_OSLC_COMPACT_XML_TYPE = new MediaType(APPLICATION, X_OSLC_COMPACT_XML);
+    String    APPLICATION_X_OSLC_COMPACT_JSON      = "application/x-oslc-compact+json";
+    MediaType APPLICATION_X_OSLC_COMPACT_JSON_TYPE = new MediaType("application",
+                                                                   "x-oslc-compact+json");
 
-	public final static String X_OSLC_COMPACT_JSON = "x-oslc-compact+json"; // TODO - Compact media type never defined in the OSLC spec for JSON
-	public final static String APPLICATION_X_OSLC_COMPACT_JSON = APPLICATION + "/" + X_OSLC_COMPACT_JSON;
-	public final static MediaType APPLICATION_X_OSLC_COMPACT_JSON_TYPE = new MediaType(APPLICATION, X_OSLC_COMPACT_JSON);
+    // Non-standard RDF serialisations
+
+    String    APPLICATION_JSON      = MediaType.APPLICATION_JSON;
+    MediaType APPLICATION_JSON_TYPE = MediaType.APPLICATION_JSON_TYPE;
+
+    String    APPLICATION_XML      = MediaType.APPLICATION_XML;
+    MediaType APPLICATION_XML_TYPE = MediaType.APPLICATION_XML_TYPE;
+
+    String    TEXT_XML      = MediaType.TEXT_XML;
+    MediaType TEXT_XML_TYPE = MediaType.TEXT_XML_TYPE;
+
+    String RDF_THRIFT_MIME = "application/rdf+thrift";
+    MediaType RDF_THRIFT_MT = MediaType.valueOf(RDF_THRIFT_MIME);
+
+    // Deprecated
+
+    @Deprecated String APPLICATION         = "application";
+    @Deprecated String TEXT                = "text";
+    @Deprecated String RDF_XML             = "rdf+xml";
+    @Deprecated String JSON_LD             = "ld+json";
+    @Deprecated String TURTLE              = "turtle";
+    @Deprecated String X_OSLC_COMPACT_XML  = "x-oslc-compact+xml";
+    @Deprecated String X_OSLC_COMPACT_JSON = "x-oslc-compact+json";
+
 }

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractOslcRdfXmlProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractOslcRdfXmlProvider.java
@@ -54,7 +54,7 @@ import org.eclipse.lyo.oslc4j.core.model.ServiceProviderCatalog;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class AbstractOslcRdfXmlProvider
+public abstract class AbstractOslcRdfXmlProvider extends AbstractRdfProvider
 {
 	private static final Logger log = LoggerFactory.getLogger(AbstractOslcRdfXmlProvider.class.getName
 			());
@@ -78,9 +78,9 @@ public abstract class AbstractOslcRdfXmlProvider
 	@Deprecated
 	public static final String OSLC4J_STRICT_DATATYPES		 = "org.eclipse.lyo.oslc4j.strictDatatypes";
 
-	private static final Annotation[] ANNOTATIONS_EMPTY_ARRAY = new Annotation[0];
-	private static final Class<Error> CLASS_OSLC_ERROR		  = Error.class;
-	private static final ErrorHandler ERROR_HANDLER			  = new ErrorHandler();
+	protected static final Annotation[] ANNOTATIONS_EMPTY_ARRAY = new Annotation[0];
+	protected static final Class<Error> CLASS_OSLC_ERROR		  = Error.class;
+	protected static final ErrorHandler ERROR_HANDLER			  = new ErrorHandler();
 
 	private @Context HttpHeaders		  httpHeaders;		  // Available only on the server
 	protected @Context HttpServletRequest httpServletRequest; // Available only on the server
@@ -193,68 +193,6 @@ public abstract class AbstractOslcRdfXmlProvider
 		return writer;
 	}
 
-	protected void writeTo(final boolean						queryResult,
-						   final Object[]						objects,
-						   final MediaType						baseMediaType,
-						   final MultivaluedMap<String, Object> map,
-						   final OutputStream					outputStream)
-			  throws WebApplicationException
-	{
-		boolean isClientSide = false;
-
-		try {
-			httpServletRequest.getMethod();
-		} catch (RuntimeException e) {
-			isClientSide = true;
-		}
-
-		String descriptionURI  = null;
-		String responseInfoURI = null;
-
-		if (queryResult && ! isClientSide)
-		{
-
-			final String method = httpServletRequest.getMethod();
-			if ("GET".equals(method))
-			{
-				descriptionURI =  OSLC4JUtils.resolveURI(httpServletRequest,true);
-				responseInfoURI = descriptionURI;
-
-				final String queryString = httpServletRequest.getQueryString();
-				if ((queryString != null) &&
-					(isOslcQuery(queryString)))
-				{
-					responseInfoURI += "?" + queryString;
-				}
-			}
-
-		}
-
-		final String serializationLanguage = getSerializationLanguage(baseMediaType);
-
-		@SuppressWarnings("unchecked")
-		final Map<String, Object> properties = isClientSide ?
-			null :
-			(Map<String, Object>)httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_SELECTED_PROPERTIES);
-		final String nextPageURI = isClientSide ?
-			null :
-			(String)httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_NEXT_PAGE);
-		final Integer totalCount = isClientSide ?
-			null :
-			(Integer)httpServletRequest.getAttribute(OSLC4JConstants.OSLC4J_TOTAL_COUNT);
-
-		ResponseInfo<?> responseInfo = new ResponseInfoArray<Object>(null, properties, totalCount, nextPageURI);
-
-		writeObjectsTo(
-				objects,
-				outputStream,
-				properties,
-				descriptionURI,
-				responseInfoURI,
-				responseInfo,
-				serializationLanguage
-		);
-	}
 
 	private String getSerializationLanguage(final MediaType baseMediaType) {
 		// Determine whether to serialize in xml or abreviated xml based upon mediatype.

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractRdfProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractRdfProvider.java
@@ -1,0 +1,114 @@
+package org.eclipse.lyo.oslc4j.provider.jena;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.RDFReader;
+import org.apache.jena.rdf.model.RDFWriter;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.riot.RDFFormat;
+import org.apache.jena.riot.RDFLanguages;
+import org.apache.jena.util.FileUtils;
+import org.eclipse.lyo.oslc4j.core.exception.MessageExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created on 2018-05-27
+ *
+ * @author Andrew Berezovskyi (andriib@kth.se)
+ * @version $version-stub$
+ * @since 0.0.1
+ */
+public class AbstractRdfProvider {
+
+    private final static Logger log = LoggerFactory.getLogger(AbstractRdfProvider.class);
+
+    protected void writeTo(final boolean queryResult, final Object[] objects,
+            final MediaType baseMediaType, final MultivaluedMap<String, Object> map,
+            final OutputStream outputStream) throws WebApplicationException {
+        String descriptionURI = null;
+        String responseInfoURI = null;
+
+        if (queryResult) {
+            throw new IllegalArgumentException("Query Result resources have to be constructed "
+                                                       + "before marshalling");
+        }
+
+        writeNonQueryObjectsTo(objects, outputStream, baseMediaType);
+    }
+
+    protected void writeNonQueryObjectsTo(final Object[] objects, final OutputStream outputStream,
+            final MediaType serializationLanguage) {
+        try {
+            final Model model = JenaModelHelper.createJenaModel(objects);
+
+            RDFWriter writer = getRdfWriter(serializationLanguage.toString(), model);
+
+            if (serializationLanguage.equals(FileUtils.langXML) || serializationLanguage.equals(
+                    FileUtils.langXMLAbbrev)) {
+                // XML (and Jena) default to UTF-8, but many libs default to ASCII, so need
+                // to set this explicitly
+                writer.setProperty("showXmlDeclaration", "false");
+                String xmlDeclaration = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+                outputStream.write(xmlDeclaration.getBytes());
+            }
+            writer.write(model, outputStream, null);
+        } catch (final Exception exception) {
+            log.warn(MessageExtractor.getMessage("ErrorSerializingResource"), exception);
+            // TODO Andrew@2018-03-03: use another exception
+            throw new WebApplicationException(exception);
+        }
+    }
+
+    private RDFWriter getRdfWriter(final String serializationLanguage, final Model model) {
+        RDFWriter writer = null;
+        if (serializationLanguage.equals(FileUtils.langXMLAbbrev)) {
+            // TODO Andrew@2018-05-27: do this for the RDF/XML-ABBREV only iff the users want it
+            /* Personally, I don't like the idea of maintaining a separate ABBREV writer. I think
+             we need to start introducing some flags where users can disable legacy functionality
+              altogether and rely on Jena etc.*/
+            writer = new RdfXmlAbbreviatedWriter();
+        } else {
+            final Lang lang = RDFLanguages.nameToLang(serializationLanguage);
+//            RDFDataMgr.createGraphWriter(mapLang(lang));
+//            final Graph graph = model.getGraph();
+            writer = model.getWriter(lang.getName());
+            // FIXME Andrew@2018-05-27: what's the purpose of name>lang>name conversion?
+        }
+        return writer;
+    }
+
+    private RDFFormat mapLang(final Lang lang) {
+        // TODO Andrew@2018-05-27: allow configuration from users (compact vs pretty etc)
+        final RDFFormat rdfFormat = new RDFFormat(lang);
+        return rdfFormat;
+    }
+
+    /*===  READER  ================================*/
+
+    protected Object[] readFrom(final Class<?> type, final MediaType mediaType, final InputStream
+            inputStream)
+            throws WebApplicationException {
+        final Model model = ModelFactory.createDefaultModel();
+        RDFDataMgr.read(
+                model,
+                inputStream,
+                RDFDataMgr.determineLang(null, mediaType.toString(), null));
+        try {
+            return JenaModelHelper.fromJenaModel(model, type);
+        } catch (final Exception exception) {
+            // FIXME Andrew@2018-05-27: we shall just stop the JMH blanket of exceptions craziness
+            throw new RuntimeException(exception);
+//            throw new WebApplicationException(exception, buildBadRequestResponse(exception,
+//                                                                      mediaType,
+//                                                                      map));
+        }
+    }
+
+}

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcJsonLdProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcJsonLdProvider.java
@@ -3,7 +3,6 @@ package org.eclipse.lyo.oslc4j.provider.jena;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.Produces;
 import javax.ws.rs.ext.Provider;
-import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 
 /**
  * Created on 2018-03-03
@@ -13,6 +12,6 @@ import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
  * @since 0.0.1
  */
 @Provider
-@Produces({OslcMediaType.JSON_LD})
-@Consumes({OslcMediaType.JSON_LD})
+@Produces({"ld+json"})
+@Consumes({"ld+json"})
 public class OslcJsonLdProvider extends OslcRdfXmlProvider{ }

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/UniversalResourceSingleProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/UniversalResourceSingleProvider.java
@@ -1,0 +1,80 @@
+package org.eclipse.lyo.oslc4j.provider.jena;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import org.eclipse.lyo.oslc4j.core.model.IResource;
+import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
+
+/**
+ * JMH accepts objects in general but there is a slight conflict in the JAX pipeline with the
+ * Collections and Arrays, which are technically also Objects. If someone needs raw Objects, they
+ * can use old Providers.
+ *
+ * @author Andrew Berezovskyi (andriib@kth.se)
+ * @version $version-stub$
+ * @since 0.0.1
+ */
+@Provider
+@Produces({OslcMediaType.APPLICATION_JSON_LD, OslcMediaType.TEXT_TURTLE, OslcMediaType
+        .N_TRIPLES_MIME, OslcMediaType.RDF_JSON_MIME, OslcMediaType.RDF_THRIFT_MIME})
+@Consumes({OslcMediaType.APPLICATION_JSON_LD, OslcMediaType.TEXT_TURTLE, OslcMediaType
+        .N_TRIPLES_MIME, OslcMediaType.RDF_JSON_MIME, OslcMediaType.RDF_THRIFT_MIME})
+public class UniversalResourceSingleProvider extends AbstractRdfProvider implements
+        MessageBodyReader<IResource>, MessageBodyWriter<IResource>
+{
+
+    private final int CANNOT_BE_DETERMINED_IN_ADVANCE = -1;
+
+    @Override
+    public boolean isReadable(final Class<?> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType) {
+        // TODO Andrew@2018-05-27: test it 
+        return true;
+    }
+
+    @Override
+    public IResource readFrom(final Class<IResource> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType,
+            final MultivaluedMap<String, String> httpHeaders, final InputStream entityStream)
+            throws IOException, WebApplicationException {
+        final Object[] objects = readFrom(type, mediaType, entityStream);
+        if(objects.length > 1) {
+            throw new IllegalArgumentException("Can't unmarshal a single resource from a model "
+                                                       + "with multiple matching resources");
+        }
+        final IResource resource = (IResource) objects[0];
+        return resource;
+    }
+
+    @Override
+    public boolean isWriteable(final Class<?> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType) {
+        // TODO Andrew@2018-05-27: test
+        return true;
+    }
+
+    @Override
+    public long getSize(final IResource iResource, final Class<?> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType) {
+        return CANNOT_BE_DETERMINED_IN_ADVANCE;
+    }
+
+    @Override
+    public void writeTo(final IResource iResource, final Class<?> type, final Type genericType,
+            final Annotation[] annotations, final MediaType mediaType,
+            final MultivaluedMap<String, Object> httpHeaders, final OutputStream entityStream)
+            throws IOException, WebApplicationException {
+        writeNonQueryObjectsTo(new Object[] {iResource}, entityStream, mediaType);
+    }
+}

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JsonLdTest.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JsonLdTest.java
@@ -6,6 +6,7 @@ import org.apache.wink.common.internal.MultivaluedMapImpl;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
 import org.eclipse.lyo.oslc4j.provider.jena.OslcJsonLdProvider;
+import org.eclipse.lyo.oslc4j.provider.jena.UniversalResourceSingleProvider;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -39,6 +40,23 @@ public class JsonLdTest {
     }
 
     @Test
+    public void testUniversalProvider() throws Exception {
+        UniversalResourceSingleProvider provider = new UniversalResourceSingleProvider();
+
+        InputStream is = ServiceProviderTest.class.getResourceAsStream("/provider.jsonld");
+        assertNotNull("Could not read file: provider.jsonld", is);
+
+        ServiceProvider p = (ServiceProvider) provider.readFrom((Class) ServiceProvider.class,
+                                                                null,
+                                                                ServiceProvider.class.getAnnotations(),
+                                                                OslcMediaType.APPLICATION_JSON_LD_TYPE,
+                                                                null,
+                                                                is);
+        assertNotNull("Provider was not read", p);
+    }
+
+
+    @Test
     public void testWrite() throws Exception {
         ServiceProvider sp = new ServiceProvider();
         sp.setDescription("Hello world");
@@ -55,4 +73,23 @@ public class JsonLdTest {
         assertTrue("Provider was not read", jsonLD.contains("Hello world"));
 
     }
+    @Test
+    public void testWriteUniversalProvider() throws Exception {
+        ServiceProvider sp = new ServiceProvider();
+        sp.setDescription("Hello world");
+        UniversalResourceSingleProvider provider = new UniversalResourceSingleProvider();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        provider.writeTo(sp, ServiceProvider.class, ServiceProvider.class, ServiceProvider.class
+                .getAnnotations(), OslcMediaType.APPLICATION_JSON_LD_TYPE, new
+                                 MultivaluedMapImpl<>(), outputStream);
+
+        final String jsonLD = outputStream.toString("UTF-8");
+
+        assertTrue("Provider was not read", jsonLD.contains("Hello world"));
+
+    }
+
+
 }


### PR DESCRIPTION
So I wanted to have a "quick" refactoring of the current JAX-RS providers. The reason for that being that all of them subclass from the RDF/XML abstract provider class.

Naturally, I began the refactoring by abstracting parts of the abstract class itself `AbstractOslcRdfXmlProvider extends AbstractRdfProvider`. But then, as I was digging into the functionality, I found that there were three main things that kept bothering me:

1. Extra checks on MIME types, checking the HTTP headers etc. I trust JAX-RS engine such as Wink to invoke my provide only when the headers match the annotated types (spoiler: in the end, Wink indeed refused to invoke my provider w/o the corresponding annotations on the service method).
2. Extra handling of RDF/XML-ABBREV serialisation. As I understand, our code defines a custom Jena writer in order to produce such serialisation. I think we still need to support it, but this patch is a demo of some fresh work that does away with hacking the hacked format.
3. **Special treatment of the OSLC Query**. It is everywhere: in the providers, in the JMH; there is a special class `org.eclipse.lyo.oslc4j.core.model.ResponseInfo` for OSLC Query response handling. Just so that you understand, everywhere as mentioned above the following is taking place: the RDFS container is constructed and manipulated in a very specific way. I am 100% sure this is not the responsibility of these classes (providers & JMH). Maybe there was no other way to craft the right Jena model, but we gotta find a solution. Jad suggested to me long time ago to allow returning a Jena `Model` from a service method. Then a provider simply serialises it w/o hitting JMH. I might envision some specific annotations, but it will still be a lot of work, because Providers look at the HTTP request headers to generate nav links!

Anyway, this patch presents:

* `AbstractRdfProvider`, which is an abstraction of the `AbstractOslcRdfXmlProvider`
* `UniversalResourceSingleProvider`, a universal provider for all formats handled by Jena for individual resources. Support for collections would require 1 or 2 more classes, but that's easy.

I modified a JSON-LD unit test and did a hand test for Turtle & N-Triples on the SPC – all work. RDF/XML can still be handled by the old providers to handle problem no. 2.
