### PR TITLE
Remove final modifier from OslcCompactRdfProvider

### DIFF
--- a/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcCompactRdfProvider.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcCompactRdfProvider.java
@@ -39,7 +39,7 @@ import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 @Provider
 @Produces(OslcMediaType.APPLICATION_X_OSLC_COMPACT_XML)
 @Consumes(OslcMediaType.APPLICATION_X_OSLC_COMPACT_XML)
-public final class OslcCompactRdfProvider
+public class OslcCompactRdfProvider
 	   extends AbstractOslcRdfXmlProvider
 	   implements MessageBodyReader<Compact>,
 				  MessageBodyWriter<Compact>


### PR DESCRIPTION
To allow WELD creating a proxy around the provider. Deploy is being stopped because of this.

Signed-off-by: Ricardo J Herrera <neormx@gmail.com>