### PR TITLE
Mark fields & arguments with Nullable/NotNull

### DIFF
--- a/org.eclipse.lyo.oslc4j.core/pom.xml
+++ b/org.eclipse.lyo.oslc4j.core/pom.xml
@@ -73,6 +73,12 @@
             <artifactId>wink-server</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>org.jetbrains</groupId>
+        <artifactId>annotations</artifactId>
+        <version>13.0</version>
+        <scope>compile</scope>
+      </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/OSLC4JUtils.java
@@ -43,6 +43,8 @@ import org.apache.jena.ext.com.google.common.base.Strings;
 import org.apache.jena.rdf.model.Property;
 import org.eclipse.lyo.oslc4j.core.model.ResourceShape;
 import org.eclipse.lyo.oslc4j.core.model.XMLLiteral;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,9 +62,9 @@ public class OSLC4JUtils {
 	 * This would result in a servletURI which is a concatenation of the baseURI and its servletPath.
 	 * (localhost:8080/adaptor-webapp/services)
 	 */
-	private static String publicURI = System.getProperty(OSLC4JConstants.OSLC4J_PUBLIC_URI);
-	private static String servletPath = null;
-	private static String servletURI = null;
+	@Nullable private static String publicURI = System.getProperty(OSLC4JConstants.OSLC4J_PUBLIC_URI);
+	@Nullable private static String servletPath = null;
+	@Nullable private static String servletURI = null;
 
 	/**
 	 * This constant should be set to true for matching the resource rdf:type to
@@ -119,8 +121,9 @@ public class OSLC4JUtils {
 	 * @throws DatatypeConfigurationException , IllegalArgumentException, InstantiationException,
 	 *                                        InvocationTargetException on
 	 */
-	public static Object getValueBasedOnResourceShapeType(final HashSet<String> rdfTypesList,
-			final QName propertyQName, final Object originalValue)
+	@Nullable
+    public static Object getValueBasedOnResourceShapeType(@Nullable final HashSet<String> rdfTypesList,
+			@Nullable final QName propertyQName, @Nullable final Object originalValue)
 			throws DatatypeConfigurationException, IllegalArgumentException, InstantiationException {
 		if (null == rdfTypesList || rdfTypesList.isEmpty() || null == propertyQName || null == originalValue) {
 			return null;
@@ -196,12 +199,12 @@ public class OSLC4JUtils {
 						Constructor<?> cons = dataTypeFromShape.getJavaClass()
 															   .getConstructor(String.class);
 						return cons.newInstance(originalValue.toString());
-					} catch (IllegalArgumentException | InvocationTargetException | DatatypeFormatException e) {
+					} catch (@NotNull IllegalArgumentException | InvocationTargetException | DatatypeFormatException e) {
 						throw new IllegalArgumentException(e);
 					}
 				}
 			}
-		} catch (NoSuchMethodException | IllegalAccessException e) {
+		} catch (@NotNull NoSuchMethodException | IllegalAccessException e) {
 			// if there is any error while creating the new object, return null,
 			// i.e use the original value and not the new one.
 			// TODO Andrew@2017-07-18: Throw exception instead of returning null
@@ -218,7 +221,8 @@ public class OSLC4JUtils {
 	 *
 	 * @return Public URI, or null if not set
 	 */
-	public static String getPublicURI()
+	@Nullable
+    public static String getPublicURI()
 	{
 		return publicURI;
 	}
@@ -229,7 +233,7 @@ public class OSLC4JUtils {
 	 * 		The new public URI to use.
 	 */
 //	 @SuppressWarnings("unused")
-	public static void setPublicURI(final String newPublicURI) throws MalformedURLException
+	public static void setPublicURI(@Nullable final String newPublicURI) throws MalformedURLException
 	{
 
 		if (newPublicURI != null && !newPublicURI.isEmpty())
@@ -245,7 +249,8 @@ public class OSLC4JUtils {
 	 *
 	 * @return Servlet Path, or its default "services/" if not set.
 	 */
-	public static String getServletPath()
+	@Nullable
+    public static String getServletPath()
 	{
 		return servletPath;
 	}
@@ -308,7 +313,8 @@ public class OSLC4JUtils {
 	 * be something like "localhost:8080/adaptor-webapp/services",
 	 * whereas the publicURI would typically be the base "localhost:8080/adaptor-webapp"
 	 */
-	public static String getServletURI()
+	@Nullable
+    public static String getServletURI()
 	{
 		return servletURI;
 	}
@@ -406,7 +412,7 @@ public class OSLC4JUtils {
 	 * @param request - request to base resolved URI on
 	 * @return String containing the resolved URI
 	 */
-	public static String resolveFullUri(HttpServletRequest request) {
+	public static String resolveFullUri(@NotNull HttpServletRequest request) {
 		final UriBuilder servletUriBuilder = servletUriBuilderFrom(request);
 
 		final String pathInfo = request.getPathInfo();
@@ -434,7 +440,7 @@ public class OSLC4JUtils {
 	 * @param request - request to base resolved URI on
 	 * @return String containing the resolved URI
 	 */
-	public static String resolveServletUri(HttpServletRequest request) {
+	public static String resolveServletUri(@NotNull HttpServletRequest request) {
 		final UriBuilder servletUriBuilder = servletUriBuilderFrom(request);
 
 		URI resolvedURI = servletUriBuilder.build().normalize();
@@ -449,7 +455,7 @@ public class OSLC4JUtils {
 	 *
 	 * @param newServletPath New servlet path to set or NULL to reset it.
 	 */
-	public static void setServletPath(String newServletPath) {
+	public static void setServletPath(@Nullable String newServletPath) {
 		if (newServletPath != null && !newServletPath.isEmpty()) {
 			//test for valid URL - exception will be thrown if invalid
 			URI testServletURI = servletUriBuilderFrom(getPublicURI(), newServletPath).build();
@@ -461,7 +467,7 @@ public class OSLC4JUtils {
 		}
 	}
 
-	private static UriBuilder servletUriBuilderFrom(final HttpServletRequest request) {
+	private static UriBuilder servletUriBuilderFrom(@NotNull final HttpServletRequest request) {
 		final String publicUri = getOrConstructPublicUriBase(request);
 		final String servletPath;
 		if (getServletPath() != null) {
@@ -478,7 +484,8 @@ public class OSLC4JUtils {
 		return UriBuilder.fromUri(publicUri).path(servletPath);
 	}
 
-	private static String getOrConstructPublicUriBase(final HttpServletRequest request) {
+	@Nullable
+    private static String getOrConstructPublicUriBase(@NotNull final HttpServletRequest request) {
 		String publicUri = getPublicURI();
 		if (publicUri == null || publicUri.isEmpty()) {
 			final String scheme = request.getScheme();
@@ -503,7 +510,7 @@ public class OSLC4JUtils {
 
 	// TODO Andrew@2017-07-18: Avoid guessing anything and prefer configuration and/or convention
 	@Deprecated
-	private static String guessHostname(final HttpServletRequest request) {
+	private static String guessHostname(@NotNull final HttpServletRequest request) {
 		String hostName = "localhost";
 
 		//try host resolution first if property to disable it is false or not set
@@ -539,7 +546,8 @@ public class OSLC4JUtils {
 	 * @return boolean value of a property, the default value if it's missing or an
 	 *         IllegalArgumentException if the property value is malformed
 	 */
-	private static Boolean parseBooleanPropertyOrDefault(final String key,
+	@Nullable
+    private static Boolean parseBooleanPropertyOrDefault(@NotNull final String key,
 			final boolean defaultValue) {
 		Boolean value = null;
 		final String property = System.getProperty(key);
@@ -572,8 +580,8 @@ public class OSLC4JUtils {
 	 * @return True if the ResourceShape type is in the list of rdf:types,
 	 *		   otherwise returns false.
 	 */
-	private static boolean doesResourceShapeMatchRdfTypes(final ResourceShape shape,
-			final HashSet<String> rdfTypesList)
+	private static boolean doesResourceShapeMatchRdfTypes(@Nullable final ResourceShape shape,
+			@NotNull final HashSet<String> rdfTypesList)
 	{
 		if (null != shape)
 		{
@@ -692,9 +700,10 @@ public class OSLC4JUtils {
 	 *			   InvocationTargetException
 	 *
 	 */
-	public static RDFDatatype getDataTypeBasedOnResourceShapeType(final HashSet<String>
+	@Nullable
+    public static RDFDatatype getDataTypeBasedOnResourceShapeType(@Nullable final HashSet<String>
 			rdfTypesList,
-			final Property property )
+			@Nullable final Property property )
 	{
 		if (null != rdfTypesList && !rdfTypesList.isEmpty() && null != property )
 		{

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/OslcGlobalNamespaceProvider.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/OslcGlobalNamespaceProvider.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcSchema;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Defines the global namespace prefix mappings.
@@ -38,7 +39,7 @@ public class OslcGlobalNamespaceProvider {
 
 	private static OslcGlobalNamespaceProvider instance;
 	
-	private Map<String, String> prefixDefinitionMap;
+	@Nullable private Map<String, String> prefixDefinitionMap;
 	
 	/**
 	 * Private construct for singleton pattern.
@@ -75,7 +76,8 @@ public class OslcGlobalNamespaceProvider {
 	 * @return empty hash map instance if there are no global
 	 *	namespace mappings.
 	 */
-	public Map<String, String> getPrefixDefinitionMap() 
+	@Nullable
+    public Map<String, String> getPrefixDefinitionMap()
 	{
 		return prefixDefinitionMap;
 	}
@@ -86,7 +88,7 @@ public class OslcGlobalNamespaceProvider {
 	 * 
 	 * @param prefixDefinitionMap that will replace the current.
 	 */
-	public void setPrefixDefinitionMap(Map<String, String> prefixDefinitionMap) 
+	public void setPrefixDefinitionMap(@Nullable Map<String, String> prefixDefinitionMap)
 	{
 		if(null == prefixDefinitionMap) 
 		{

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/UnparseableLiteral.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/UnparseableLiteral.java
@@ -17,6 +17,8 @@
  *******************************************************************************/
 package org.eclipse.lyo.oslc4j.core;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Represents properties whose value is not valid for the declared
  * datatype. This enables clients to at least see the raw value and
@@ -57,7 +59,8 @@ public class UnparseableLiteral
 		this.datatype = value;
 	}
 
-	public String toString()
+	@NotNull
+    public String toString()
 	{
 		return "unparseable literal: \""+this.rawValue+"\"^^<"+this.datatype+">";
 	}

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcAllowedValue.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcAllowedValue.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,5 +33,5 @@ public @interface OslcAllowedValue {
 	/**
 	 * A value allowed for property, inlined into property definition.
 	 */
-	String[] value();
+    @NotNull String[] value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcAllowedValues.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcAllowedValues.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,5 +33,5 @@ public @interface OslcAllowedValues {
 	/**
 	 * Specify how the resource will be represented (for properties with a resource value-type).
 	 */
-	String value();
+    @NotNull String value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcCreationFactory.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcCreationFactory.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,25 +33,25 @@ public @interface OslcCreationFactory {
 	/**
 	 * Title string that could be used for display
 	 */
-	String title();
+    @NotNull String title();
 
 	/**
 	 * Very short label for use in menu items
 	 */
-	String label() default "";
+    @NotNull String label() default "";
 
 	/**
 	 * Resource shapes
 	 */
-	String[] resourceShapes() default {};
+    @NotNull String[] resourceShapes() default {};
 
 	/**
 	 * Resource types
 	 */
-	String[] resourceTypes() default {};
+    @NotNull String[] resourceTypes() default {};
 
 	/**
 	 * Usages
 	 */
-	String[] usages() default {};
+    @NotNull String[] usages() default {};
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcDefaultValue.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcDefaultValue.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,5 +33,5 @@ public @interface OslcDefaultValue {
 	/**
 	 * A default value for property, inlined into property definition.
 	 */
-	String value();
+    @NotNull String value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcDescription.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcDescription.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,5 +33,5 @@ public @interface OslcDescription {
 	/**
 	 *	Description of the element.
 	 */
-	String value();
+    @NotNull String value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcDialog.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcDialog.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,35 +33,35 @@ public @interface OslcDialog {
 	/**
 	 * Title string that could be used for display
 	 */
-	String title();
+    @NotNull String title();
 
 	/**
 	 * Very short label for use in menu items
 	 */
-	String label() default "";
+    @NotNull String label() default "";
 
 	/**
 	 * The URI of the dialog
 	 */
-	String uri();
+    @NotNull String uri();
 
 	/**
 	 * Values MUST be expressed in relative length units.  Em and ex units are interpreted relative to the default system font (at 100% size).
 	 */
-	String hintWidth() default "";
+    @NotNull String hintWidth() default "";
 
 	/**
 	 * Values MUST be expressed in relative length units.  Em and ex units are interpreted relative to the default system font (at 100% size).
 	 */
-	String hintHeight() default "";
+    @NotNull String hintHeight() default "";
 
 	/**
 	 * Resource types
 	 */
-	String[] resourceTypes() default {};
+    @NotNull String[] resourceTypes() default {};
 
 	/**
 	 * Usages
 	 */
-	String[] usages() default {};
+    @NotNull String[] usages() default {};
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcDialogs.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcDialogs.java
@@ -24,10 +24,11 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface OslcDialogs {
-	OslcDialog[] value();
+	@NotNull OslcDialog[] value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcName.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcName.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target({ElementType.TYPE, ElementType.METHOD})
@@ -32,5 +33,5 @@ public @interface OslcName {
 	/**
 	 *	Name of the element.
 	 */
-	String value();
+    @NotNull String value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcNamespace.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcNamespace.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.TYPE)
@@ -32,5 +33,5 @@ public @interface OslcNamespace {
 	/**
 	 * Namespace URI of the element.
 	 */
-	String value();
+    @NotNull String value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcNamespaceDefinition.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcNamespaceDefinition.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target({}) // Only used within OslcSchema
@@ -31,10 +32,10 @@ public @interface OslcNamespaceDefinition {
 	/**
 	 * Namespace URI.
 	 */
-	String namespaceURI();
+    @NotNull String namespaceURI();
 
 	/**
 	 * Prefix for the namespace.
 	 */
-	String prefix();
+    @NotNull String prefix();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcOccurs.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcOccurs.java
@@ -26,6 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -34,5 +35,5 @@ public @interface OslcOccurs {
 	/**
 	 * Occurs of property.
 	 */
-	Occurs value();
+    @NotNull Occurs value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcPropertyDefinition.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcPropertyDefinition.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,5 +33,5 @@ public @interface OslcPropertyDefinition {
 	/**
 	 * URI of the property whose usage is being described.
 	 */
-	String value();
+    @NotNull String value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcQueryCapability.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcQueryCapability.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,25 +33,25 @@ public @interface OslcQueryCapability {
 	/**
 	 * Title string that could be used for display
 	 */
-	String title();
+    @NotNull String title();
 
 	/**
 	 * Very short label for use in menu items
 	 */
-	String label() default "";
+    @NotNull String label() default "";
 
 	/**
 	 * Resource shapes
 	 */
-	String resourceShape() default "";
+    @NotNull String resourceShape() default "";
 
 	/**
 	 * Resource types
 	 */
-	String[] resourceTypes() default {};
+    @NotNull String[] resourceTypes() default {};
 
 	/**
 	 * Usages
 	 */
-	String[] usages() default {};
+    @NotNull String[] usages() default {};
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcRange.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcRange.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,5 +33,5 @@ public @interface OslcRange {
 	/**
 	 * Specify the range of possible resource types allowed (for properties with a resource value-type).
 	 */
-	String[] value();
+    @NotNull String[] value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcRdfCollectionType.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcRdfCollectionType.java
@@ -23,6 +23,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.eclipse.lyo.oslc4j.core.model.OslcConstants;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Indicate which RDF: collection type should be used for representing
@@ -41,10 +42,10 @@ public @interface OslcRdfCollectionType
 	/**
 	 * Namespace URI.
 	 */
-	String namespaceURI() default OslcConstants.RDF_NAMESPACE;
+    @NotNull String namespaceURI() default OslcConstants.RDF_NAMESPACE;
 
 	/**
 	 * Prefix for the namespace.
 	 */
-	String collectionType() default "List";
+    @NotNull String collectionType() default "List";
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcRepresentation.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcRepresentation.java
@@ -26,6 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.eclipse.lyo.oslc4j.core.model.Representation;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -34,5 +35,5 @@ public @interface OslcRepresentation {
 	/**
 	 * Specify how the resource will be represented (for properties with a resource value-type).
 	 */
-	Representation value();
+    @NotNull Representation value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcResourceShape.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcResourceShape.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.TYPE)
@@ -32,10 +33,10 @@ public @interface OslcResourceShape {
 	/**
 	 * Title of the resource shape.
 	 */
-	String title() default "";
+    @NotNull String title() default "";
 
 	/**
 	 * Type or types of resource described by this shape.
 	 */
-	String[] describes() default {};
+    @NotNull String[] describes() default {};
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcSchema.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcSchema.java
@@ -27,6 +27,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.eclipse.lyo.oslc4j.core.model.IOslcCustomNamespaceProvider;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.PACKAGE)
@@ -36,7 +37,7 @@ public @interface OslcSchema {
 	/**
 	 * The namespace mappings for the package.
 	 */
-	OslcNamespaceDefinition[] value();
+    @NotNull OslcNamespaceDefinition[] value();
 
 	/**
 	 * Any class that implements the {@link IOslcCustomNamespaceProvider}.
@@ -46,6 +47,6 @@ public @interface OslcSchema {
 	 * because this field must not be required and since it is not a concrete
 	 * implementation of the interface it will be ignored.
 	 */
-	Class<? extends IOslcCustomNamespaceProvider> customNamespaceProvider() default IOslcCustomNamespaceProvider.class;
+    @NotNull Class<? extends IOslcCustomNamespaceProvider> customNamespaceProvider() default IOslcCustomNamespaceProvider.class;
 
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcService.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcService.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.TYPE)
@@ -32,5 +33,5 @@ public @interface OslcService {
 	/**
 	 * Domain of the service.
 	 */
-	String value();
+    @NotNull String value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcTitle.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcTitle.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -32,5 +33,5 @@ public @interface OslcTitle {
 	/**
 	 *	Title of the element.
 	 */
-	String value();
+    @NotNull String value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcValueShape.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcValueShape.java
@@ -24,6 +24,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -33,5 +34,5 @@ public @interface OslcValueShape {
 	 * If the value-type is a resource type, then Property MAY provide a shape value
 	 * to indicate the Resource Shape that applies to the resource.
 	 */
-	String value();
+    @NotNull String value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcValueType.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/annotation/OslcValueType.java
@@ -26,6 +26,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
+import org.jetbrains.annotations.NotNull;
 
 @Documented
 @Target(ElementType.METHOD)
@@ -34,5 +35,5 @@ public @interface OslcValueType {
 	/**
 	 * Value-type of the property.
 	 */
-	ValueType value();
+    @NotNull ValueType value();
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/MessageExtractor.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/MessageExtractor.java
@@ -23,6 +23,8 @@ import java.text.MessageFormat;
 import java.util.Locale;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,26 +33,27 @@ public class MessageExtractor {
 	private final static Logger log = LoggerFactory.getLogger(MessageExtractor.class);
 	private static final String CLASS = MessageExtractor.class.getName();
 	private static final String BUNDLE_NAME = "messages/oslc4jcore";
-	private static ResourceBundle bundle = null;
+	@Nullable private static ResourceBundle bundle = null;
 
 	private MessageExtractor(){
 	}
 
-	private static synchronized ResourceBundle getMessageBundle(final Locale locale){
+	@Nullable
+    private static synchronized ResourceBundle getMessageBundle(@NotNull final Locale locale){
 		if(bundle == null) {
 			bundle = ResourceBundle.getBundle(BUNDLE_NAME, locale);
 		}
 		return bundle;
 	}
 
-	private static String getString(final Locale locale, final String key, final Object[] args ) {
+	private static String getString(@NotNull final Locale locale, @NotNull final String key, final Object[] args ) {
 		final ResourceBundle messages = getMessageBundle(locale);
 
 		if (messages != null) {
 			try {
 				final String message = messages.getString( key );
 				return formatMessage(locale, message, args);
-			} catch ( final MissingResourceException missingResourceException ) {
+			} catch ( @NotNull final MissingResourceException missingResourceException ) {
 				log.error("Resource {} is missing", key, missingResourceException);
 				return "???" + key + "???";
 			}
@@ -61,24 +64,24 @@ public class MessageExtractor {
 		return "???" + key + "???";
 	}
 
-	private static String formatMessage(final Locale locale, final String message, final Object[] args) {
+	private static String formatMessage(final Locale locale, @NotNull final String message, final Object[] args) {
 		final String fixedMessage = FixMessageFormat.fixPattern(message);
 		return new MessageFormat(fixedMessage, locale).format(args);
 	}
 
-	public static String getMessage(final Locale locale, final String key, final Object[] params){
+	public static String getMessage(@NotNull final Locale locale, @NotNull final String key, final Object[] params){
 		return getString(locale, key, params);
 	}
 
-	public static String getMessage(final Locale locale, final String key){
+	public static String getMessage(@NotNull final Locale locale, @NotNull final String key){
 		return getMessage(locale, key, null);
 	}
 
-	public static String getMessage(final String key){
+	public static String getMessage(@NotNull final String key){
 		return getMessage(key, null);
 	}
 
-	public static String getMessage(final String key, final Object[] params){
+	public static String getMessage(@NotNull final String key, final Object[] params){
 		return getMessage(Locale.getDefault(), key, params);
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreApplicationException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreApplicationException.java
@@ -18,17 +18,19 @@
  *******************************************************************************/
 package org.eclipse.lyo.oslc4j.core.exception;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Base class for all application exceptions.
  */
 public abstract class OslcCoreApplicationException extends Exception {
 	private static final long serialVersionUID = -5933150329026674184L;
 
-	public OslcCoreApplicationException(final String messageKey, final Object[] args) {
+	public OslcCoreApplicationException(@NotNull final String messageKey, final Object[] args) {
 		super(MessageExtractor.getMessage(messageKey, args));
 	}
 
-	public OslcCoreApplicationException(final String messageKey, final Object[] args, final Throwable t) {
+	public OslcCoreApplicationException(@NotNull final String messageKey, final Object[] args, final Throwable t) {
 		super(MessageExtractor.getMessage(messageKey, args), t);
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreDeregistrationException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreDeregistrationException.java
@@ -19,6 +19,7 @@
 package org.eclipse.lyo.oslc4j.core.exception;
 
 import java.net.URI;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreDeregistrationException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = 2969548886287595367L;
@@ -26,7 +27,7 @@ public final class OslcCoreDeregistrationException extends OslcCoreApplicationEx
 	private static final String MESSAGE_KEY = "DeregistrationException";
 
 	private final String responseMessage;
-	private final URI	 serviceProviderURI;
+	@NotNull private final URI	 serviceProviderURI;
 	private final int	 statusCode;
 
 	public OslcCoreDeregistrationException(final URI serviceProviderURI, final int statusCode, final String responseMessage) {
@@ -41,7 +42,8 @@ public final class OslcCoreDeregistrationException extends OslcCoreApplicationEx
 		return responseMessage;
 	}
 
-	public URI getServiceProviderURI() {
+	@NotNull
+    public URI getServiceProviderURI() {
 		return serviceProviderURI;
 	}
 

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreDuplicatePropertyDefinitionException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreDuplicatePropertyDefinitionException.java
@@ -19,14 +19,15 @@
 package org.eclipse.lyo.oslc4j.core.exception;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreDuplicatePropertyDefinitionException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = 7981216864868316487L;
 
 	private static final String MESSAGE_KEY = "DuplicatePropertyDefinitionException";
 
-	private final OslcPropertyDefinition oslcPropertyDefinition;
-	private final Class<?>				 resourceClass;
+	@NotNull private final OslcPropertyDefinition oslcPropertyDefinition;
+	@NotNull private final Class<?>				 resourceClass;
 
 	public OslcCoreDuplicatePropertyDefinitionException(final Class<?> resourceClass, final OslcPropertyDefinition oslcPropertyDefinition) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), oslcPropertyDefinition.value()});
@@ -35,12 +36,14 @@ public final class OslcCoreDuplicatePropertyDefinitionException extends OslcCore
 		this.resourceClass			= resourceClass;
 	}
 
-	public OslcPropertyDefinition getOslcPropertyDefinition()
+	@NotNull
+    public OslcPropertyDefinition getOslcPropertyDefinition()
 	{
 		return oslcPropertyDefinition;
 	}
 
-	public Class<?> getResourceClass() {
+	@NotNull
+    public Class<?> getResourceClass() {
 		return resourceClass;
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidOccursException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidOccursException.java
@@ -21,15 +21,16 @@ package org.eclipse.lyo.oslc4j.core.exception;
 import java.lang.reflect.Method;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreInvalidOccursException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = 8373429675756819476L;
 
 	private static final String MESSAGE_KEY = "InvalidOccursException";
 
-	private final Method	 method;
-	private final OslcOccurs oslcOccurs;
-	private final Class<?>	 resourceClass;
+	@NotNull private final Method	 method;
+	@NotNull private final OslcOccurs oslcOccurs;
+	@NotNull private final Class<?>	 resourceClass;
 
 	public OslcCoreInvalidOccursException(final Class<?> resourceClass, final Method method, final OslcOccurs oslcOccurs) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), method.getName(), oslcOccurs.value().toString()});
@@ -39,15 +40,18 @@ public final class OslcCoreInvalidOccursException extends OslcCoreApplicationExc
 		this.resourceClass = resourceClass;
 	}
 
-	public Method getMethod() {
+	@NotNull
+    public Method getMethod() {
 		return method;
 	}
 
-	public OslcOccurs getOslcOccurs() {
+	@NotNull
+    public OslcOccurs getOslcOccurs() {
 		return oslcOccurs;
 	}
 
-	public Class<?> getResourceClass() {
+	@NotNull
+    public Class<?> getResourceClass() {
 		return resourceClass;
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidPropertyDefinitionException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidPropertyDefinitionException.java
@@ -21,15 +21,16 @@ package org.eclipse.lyo.oslc4j.core.exception;
 import java.lang.reflect.Method;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreInvalidPropertyDefinitionException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = 6043500589743612250L;
 
 	private static final String MESSAGE_KEY = "InvalidPropertyDefinitionException";
 
-	private final Method				 method;
-	private final OslcPropertyDefinition oslcPropertyDefinition;
-	private final Class<?>				 resourceClass;
+	@NotNull private final Method				 method;
+	@NotNull private final OslcPropertyDefinition oslcPropertyDefinition;
+	@NotNull private final Class<?>				 resourceClass;
 
 	public OslcCoreInvalidPropertyDefinitionException(final Class<?> resourceClass, final Method method, final OslcPropertyDefinition oslcPropertyDefinition) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), method.getName(), oslcPropertyDefinition.value()});
@@ -39,16 +40,19 @@ public final class OslcCoreInvalidPropertyDefinitionException extends OslcCoreAp
 		this.resourceClass			= resourceClass;
 	}
 
-	public Method getMethod() {
+	@NotNull
+    public Method getMethod() {
 		return method;
 	}
 
-	public OslcPropertyDefinition getOslcPropertyDefinition()
+	@NotNull
+    public OslcPropertyDefinition getOslcPropertyDefinition()
 	{
 		return oslcPropertyDefinition;
 	}
 
-	public Class<?> getResourceClass() {
+	@NotNull
+    public Class<?> getResourceClass() {
 		return resourceClass;
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidPropertyTypeException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidPropertyTypeException.java
@@ -19,15 +19,16 @@
 package org.eclipse.lyo.oslc4j.core.exception;
 
 import java.lang.reflect.Method;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreInvalidPropertyTypeException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = -6885356099037103377L;
 
 	private static final String MESSAGE_KEY = "InvalidPropertyTypeException";
 
-	private final Method   method;
-	private final Class<?> resourceClass;
-	private final Class<?> returnType;
+	@NotNull private final Method   method;
+	@NotNull private final Class<?> resourceClass;
+	@NotNull private final Class<?> returnType;
 
 	public OslcCoreInvalidPropertyTypeException(final Class<?> resourceClass, final Method method, final Class<?> returnType) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), method.getName(), returnType.getName()});
@@ -37,15 +38,18 @@ public final class OslcCoreInvalidPropertyTypeException extends OslcCoreApplicat
 		this.returnType	   = returnType;
 	}
 
-	public Method getMethod() {
+	@NotNull
+    public Method getMethod() {
 		return method;
 	}
 
-	public Class<?> getResourceClass() {
+	@NotNull
+    public Class<?> getResourceClass() {
 		return resourceClass;
 	}
 
-	public Class<?> getReturnType() {
+	@NotNull
+    public Class<?> getReturnType() {
 		return returnType;
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidRepresentationException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidRepresentationException.java
@@ -21,15 +21,16 @@ package org.eclipse.lyo.oslc4j.core.exception;
 import java.lang.reflect.Method;
 
 import org.eclipse.lyo.oslc4j.core.model.Representation;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreInvalidRepresentationException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = -3803394959079264170L;
 
 	private static final String MESSAGE_KEY = "InvalidRepresentationException";
 
-	private final Method		 method;
-	private final Representation representation;
-	private final Class<?>		 resourceClass;
+	@NotNull private final Method		 method;
+	@NotNull private final Representation representation;
+	@NotNull private final Class<?>		 resourceClass;
 
 	public OslcCoreInvalidRepresentationException(final Class<?> resourceClass, final Method method, final Representation representation) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), method.getName(), representation.toString()});
@@ -39,15 +40,18 @@ public final class OslcCoreInvalidRepresentationException extends OslcCoreApplic
 		this.resourceClass	= resourceClass;
 	}
 
-	public Method getMethod() {
+	@NotNull
+    public Method getMethod() {
 		return method;
 	}
 
-	public Representation getRepresentation() {
+	@NotNull
+    public Representation getRepresentation() {
 		return representation;
 	}
 
-	public Class<?> getResourceClass() {
+	@NotNull
+    public Class<?> getResourceClass() {
 		return resourceClass;
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidValueTypeException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreInvalidValueTypeException.java
@@ -21,15 +21,16 @@ package org.eclipse.lyo.oslc4j.core.exception;
 import java.lang.reflect.Method;
 
 import org.eclipse.lyo.oslc4j.core.model.ValueType;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreInvalidValueTypeException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = -989384752764371312L;
 
 	private static final String MESSAGE_KEY = "InvalidValueTypeException";
 
-	private final Method	method;
-	private final Class<?>	resourceClass;
-	private final ValueType valueType;
+	@NotNull private final Method	method;
+	@NotNull private final Class<?>	resourceClass;
+	@NotNull private final ValueType valueType;
 
 	public OslcCoreInvalidValueTypeException(final Class<?> resourceClass, final Method method, final ValueType valueType) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), method.getName(), valueType.toString()});
@@ -39,15 +40,18 @@ public final class OslcCoreInvalidValueTypeException extends OslcCoreApplication
 		this.valueType	   = valueType;
 	}
 
-	public Method getMethod() {
+	@NotNull
+    public Method getMethod() {
 		return method;
 	}
 
-	public Class<?> getResourceClass() {
+	@NotNull
+    public Class<?> getResourceClass() {
 		return resourceClass;
 	}
 
-	public ValueType getValueType() {
+	@NotNull
+    public ValueType getValueType() {
 		return valueType;
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreMissingAnnotationException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreMissingAnnotationException.java
@@ -18,13 +18,15 @@
  *******************************************************************************/
 package org.eclipse.lyo.oslc4j.core.exception;
 
+import org.jetbrains.annotations.NotNull;
+
 public final class OslcCoreMissingAnnotationException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = 247462012895583998L;
 
 	private static final String MESSAGE_KEY = "MissingAnnotationException";
 
-	private final Class<?> annotationClass;
-	private final Class<?> resourceClass;
+	@NotNull private final Class<?> annotationClass;
+	@NotNull private final Class<?> resourceClass;
 
 	public OslcCoreMissingAnnotationException(final Class<?> resourceClass, final Class<?> annotationClass) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), annotationClass.getName()});
@@ -33,11 +35,13 @@ public final class OslcCoreMissingAnnotationException extends OslcCoreApplicatio
 		this.resourceClass	 = resourceClass;
 	}
 
-	public Class<?> getAnnotationClass() {
+	@NotNull
+    public Class<?> getAnnotationClass() {
 		return annotationClass;
 	}
 
-	public Class<?> getResourceClass() {
+	@NotNull
+    public Class<?> getResourceClass() {
 		return resourceClass;
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreMissingSetMethodException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreMissingSetMethodException.java
@@ -19,14 +19,15 @@
 package org.eclipse.lyo.oslc4j.core.exception;
 
 import java.lang.reflect.Method;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreMissingSetMethodException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = 4513570830160136304L;
 
 	private static final String MESSAGE_KEY = "MissingSetMethodException";
 
-	private final Class<?> resourceClass;
-	private final Method   getMethod;
+	@NotNull private final Class<?> resourceClass;
+	@NotNull private final Method   getMethod;
 
 	public OslcCoreMissingSetMethodException(final Class<?> resourceClass, final Method getMethod, final Exception exception) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), getMethod.getName()}, exception);
@@ -35,12 +36,14 @@ public final class OslcCoreMissingSetMethodException extends OslcCoreApplication
 		this.resourceClass = resourceClass;
 	}
 
-	public Method getGetMethod()
+	@NotNull
+    public Method getGetMethod()
 	{
 		return getMethod;
 	}
 
-	public Class<?> getResourceClass()
+	@NotNull
+    public Class<?> getResourceClass()
 	{
 		return resourceClass;
 	}

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreMisusedOccursException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreMisusedOccursException.java
@@ -19,14 +19,15 @@
 package org.eclipse.lyo.oslc4j.core.exception;
 
 import java.lang.reflect.Method;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreMisusedOccursException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = -7018793552909566125L;
 
 	private static final String MESSAGE_KEY = "MisusedOccursException";
 
-	private final Method	 method;
-	private final Class<?>	 resourceClass;
+	@NotNull private final Method	 method;
+	@NotNull private final Class<?>	 resourceClass;
 
 	public OslcCoreMisusedOccursException(final Class<?> resourceClass, final Method method) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), method.getName()});
@@ -35,11 +36,13 @@ public final class OslcCoreMisusedOccursException extends OslcCoreApplicationExc
 		this.resourceClass = resourceClass;
 	}
 
-	public Method getMethod() {
+	@NotNull
+    public Method getMethod() {
 		return method;
 	}
 
-	public Class<?> getResourceClass() {
+	@NotNull
+    public Class<?> getResourceClass() {
 		return resourceClass;
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreRegistrationException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreRegistrationException.java
@@ -19,6 +19,7 @@
 package org.eclipse.lyo.oslc4j.core.exception;
 
 import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreRegistrationException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = 2094758752309893978L;
@@ -26,7 +27,7 @@ public final class OslcCoreRegistrationException extends OslcCoreApplicationExce
 	private static final String MESSAGE_KEY = "RegistrationException";
 
 	private final String		  responseMessage;
-	private final ServiceProvider serviceProvider;
+	@NotNull private final ServiceProvider serviceProvider;
 	private final int			  statusCode;
 
 	public OslcCoreRegistrationException(final ServiceProvider serviceProvider, final int statusCode, final String responseMessage) {
@@ -41,7 +42,8 @@ public final class OslcCoreRegistrationException extends OslcCoreApplicationExce
 		return responseMessage;
 	}
 
-	public ServiceProvider getServiceProvider() {
+	@NotNull
+    public ServiceProvider getServiceProvider() {
 		return serviceProvider;
 	}
 

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreRelativeURIException.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/exception/OslcCoreRelativeURIException.java
@@ -19,6 +19,7 @@
 package org.eclipse.lyo.oslc4j.core.exception;
 
 import java.net.URI;
+import org.jetbrains.annotations.NotNull;
 
 public final class OslcCoreRelativeURIException extends OslcCoreApplicationException {
 	private static final long serialVersionUID = -1238625637837216499L;
@@ -26,8 +27,8 @@ public final class OslcCoreRelativeURIException extends OslcCoreApplicationExcep
 	private static final String MESSAGE_KEY = "RelativeURIException";
 
 	private final String   methodName;
-	private final URI	   relativeURI;
-	private final Class<?> resourceClass;
+	@NotNull private final URI	   relativeURI;
+	@NotNull private final Class<?> resourceClass;
 
 	public OslcCoreRelativeURIException(final Class<?> resourceClass, final String methodName, final URI relativeURI) {
 		super(MESSAGE_KEY, new Object[] {resourceClass.getName(), methodName, relativeURI.toString()});
@@ -41,11 +42,13 @@ public final class OslcCoreRelativeURIException extends OslcCoreApplicationExcep
 		return methodName;
 	}
 
-	public URI getRelativeURI() {
+	@NotNull
+    public URI getRelativeURI() {
 		return relativeURI;
 	}
 
-	public Class<?> getResourceClass() {
+	@NotNull
+    public Class<?> getResourceClass() {
 		return resourceClass;
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/AllowedValues.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/AllowedValues.java
@@ -28,6 +28,7 @@ import javax.xml.namespace.QName;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.jetbrains.annotations.NotNull;
 
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Allowed Values Resource Shape",
@@ -40,6 +41,7 @@ public final class AllowedValues extends AbstractResource {
         super();
     }
 
+    @NotNull
     public Collection<?> getValues() {
         Object o = getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
         if (o == null) {

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/CreationFactory.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/CreationFactory.java
@@ -35,6 +35,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Creation Factory Resource Shape", describes = OslcConstants.TYPE_CREATION_FACTORY)
@@ -87,7 +89,8 @@ public class CreationFactory extends AbstractResource {
 		return label;
 	}
 
-	@OslcDescription("A creation factory may provide resource shapes that describe shapes of resources that may be created")
+	@NotNull
+    @OslcDescription("A creation factory may provide resource shapes that describe shapes of resources that may be created")
 	@OslcName("resourceShape")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "resourceShape")
 	@OslcRange(OslcConstants.TYPE_RESOURCE_SHAPE)
@@ -98,7 +101,8 @@ public class CreationFactory extends AbstractResource {
 		return resourceShapes.toArray(new URI[resourceShapes.size()]);
 	}
 
-	@OslcDescription("The expected resource type URI of the resource that will be created using this creation factory. These would be the URIs found in the result resource's rdf:type property")
+	@NotNull
+    @OslcDescription("The expected resource type URI of the resource that will be created using this creation factory. These would be the URIs found in the result resource's rdf:type property")
 	@OslcName("resourceType")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "resourceType")
 	@OslcReadOnly
@@ -117,7 +121,8 @@ public class CreationFactory extends AbstractResource {
 		return title;
 	}
 
-	@OslcDescription("An identifier URI for the domain specified usage of this creation factory. If a service provides multiple creation factories, it may designate the primary or default one that should be used with a property value of http://open-services.net/ns/core#default")
+	@NotNull
+    @OslcDescription("An identifier URI for the domain specified usage of this creation factory. If a service provides multiple creation factories, it may designate the primary or default one that should be used with a property value of http://open-services.net/ns/core#default")
 	@OslcName("usage")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "usage")
 	@OslcReadOnly
@@ -134,14 +139,14 @@ public class CreationFactory extends AbstractResource {
 		this.label = label;
 	}
 
-	public void setResourceShapes(final URI[] resourceShapes) {
+	public void setResourceShapes(@Nullable final URI[] resourceShapes) {
 		this.resourceShapes.clear();
 		if (resourceShapes != null) {
 			this.resourceShapes.addAll(Arrays.asList(resourceShapes));
 		}
 	}
 
-	public void setResourceTypes(final URI[] resourceTypes) {
+	public void setResourceTypes(@Nullable final URI[] resourceTypes) {
 		this.resourceTypes.clear();
 		if (resourceTypes != null) {
 			this.resourceTypes.addAll(Arrays.asList(resourceTypes));
@@ -152,7 +157,7 @@ public class CreationFactory extends AbstractResource {
 		this.title = title;
 	}
 
-	public void setUsages(final URI[] usages) {
+	public void setUsages(@Nullable final URI[] usages) {
 		this.usages.clear();
 		if (usages != null) {
 			this.usages.addAll(Arrays.asList(usages));

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Dialog.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Dialog.java
@@ -33,6 +33,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Dialog Resource Shape", describes = OslcConstants.TYPE_DIALOG)
@@ -98,7 +100,8 @@ public class Dialog extends AbstractResource {
 		return label;
 	}
 
-	@OslcDescription("The expected resource type URI for the resources that will be returned when using this dialog. These would be the URIs found in the result resource's rdf:type property")
+	@NotNull
+    @OslcDescription("The expected resource type URI for the resources that will be returned when using this dialog. These would be the URIs found in the result resource's rdf:type property")
 	@OslcName("resourceType")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "resourceType")
 	@OslcReadOnly
@@ -117,7 +120,8 @@ public class Dialog extends AbstractResource {
 		return title;
 	}
 
-	@OslcDescription("An identifier URI for the domain specified usage of this dialog. If a service provides multiple selection or creation dialogs, it may designate the primary or default one that should be used with a property value of http://open-services/ns/core#default")
+	@NotNull
+    @OslcDescription("An identifier URI for the domain specified usage of this dialog. If a service provides multiple selection or creation dialogs, it may designate the primary or default one that should be used with a property value of http://open-services/ns/core#default")
 	@OslcName("usage")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "usage")
 	@OslcReadOnly
@@ -142,7 +146,7 @@ public class Dialog extends AbstractResource {
 		this.label = label;
 	}
 
-	public void setResourceTypes(final URI[] resourceTypes) {
+	public void setResourceTypes(@Nullable final URI[] resourceTypes) {
 		this.resourceTypes.clear();
 		if (resourceTypes != null) {
 			this.resourceTypes.addAll(Arrays.asList(resourceTypes));
@@ -153,7 +157,7 @@ public class Dialog extends AbstractResource {
 		this.title = title;
 	}
 
-	public void setUsages(final URI[] usages) {
+	public void setUsages(@Nullable final URI[] usages) {
 		this.usages.clear();
 		if (usages != null) {
 			this.usages.addAll(Arrays.asList(usages));

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/InheritedMethodAnnotationHelper.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/InheritedMethodAnnotationHelper.java
@@ -20,6 +20,7 @@ package org.eclipse.lyo.oslc4j.core.model;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import org.jetbrains.annotations.NotNull;
 
 public final class InheritedMethodAnnotationHelper
 {
@@ -29,7 +30,7 @@ public final class InheritedMethodAnnotationHelper
 	}
 	
 	public static <T extends Annotation> T getAnnotation(final Method	method,
-														 final Class<T> annotationClass)
+														 @NotNull final Class<T> annotationClass)
 	{
 		// First, try method for annotation
 
@@ -60,7 +61,7 @@ public final class InheritedMethodAnnotationHelper
 					return superClassMethodAnnotation;
 				}
 			}
-			catch (final Exception exception)
+			catch (@NotNull final Exception exception)
 			{
 				// Ignore and fall through to code below
 			}
@@ -95,9 +96,9 @@ public final class InheritedMethodAnnotationHelper
 		return null;
 	}
 
-	private static <T extends Annotation> T getRecursiveInterfaceMethodAnnotation(final Class<?> interfac,
-																				  final Method	 method,
-																				  final Class<T> annotationClass)
+	private static <T extends Annotation> T getRecursiveInterfaceMethodAnnotation(@NotNull final Class<?> interfac,
+																				  @NotNull final Method	 method,
+																				  @NotNull final Class<T> annotationClass)
 	{
 		try
 		{
@@ -111,7 +112,7 @@ public final class InheritedMethodAnnotationHelper
 				return interfaceMethodAnnotation;
 			}
 		}
-		catch (final Exception exception)
+		catch (@NotNull final Exception exception)
 		{
 			// Ignore and fall through to code below
 		}

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Occurs.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Occurs.java
@@ -19,6 +19,7 @@
 package org.eclipse.lyo.oslc4j.core.model;
 
 import java.net.URI;
+import org.jetbrains.annotations.Nullable;
 
 public enum Occurs {
 	ExactlyOne(OslcConstants.OSLC_CORE_NAMESPACE + "Exactly-one"),
@@ -47,7 +48,8 @@ public enum Occurs {
 		return null;
 	}
 	
-	public static Occurs fromURI(final URI uri) {
+	@Nullable
+    public static Occurs fromURI(final URI uri) {
 		return fromString(uri.toString());
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Property.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Property.java
@@ -41,6 +41,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Property Resource Shape", describes = OslcConstants.TYPE_PROPERTY)
@@ -49,19 +51,19 @@ public final class Property extends AbstractResource implements Comparable<Prope
 	private static final QName PROPERTY_DEFAULT_VALUE = new QName(OslcConstants.OSLC_CORE_NAMESPACE, "defaultValue");
 	private final List<URI> range = new ArrayList<URI>();
 
-	private URI allowedValuesRef;
+	@Nullable private URI allowedValuesRef;
 	private String description;
 	private Boolean hidden;
 	private Integer maxSize;
 	private Boolean memberProperty;
 	private String name;
-	private Occurs occurs;
+	@Nullable private Occurs occurs;
 	private URI propertyDefinition;
 	private Boolean readOnly;
-	private Representation representation;
+	@Nullable private Representation representation;
 	private String title;
 	private URI valueShape;
-	private ValueType valueType;
+	@Nullable private ValueType valueType;
 
 	public Property() {
 		super();
@@ -88,7 +90,8 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		return name.compareTo(o.getName());
 	}
 
-	@OslcDescription("Resource with allowed values for the property being defined")
+	@Nullable
+    @OslcDescription("Resource with allowed values for the property being defined")
 	@OslcName("allowedValues")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "allowedValues")
 	@OslcRange(OslcConstants.TYPE_ALLOWED_VALUES)
@@ -153,7 +156,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		if (occurs != null) {
 			try {
 				return new URI(occurs.toString());
-			} catch (final URISyntaxException exception) {
+			} catch (@NotNull final URISyntaxException exception) {
 				// This should never happen since we control the possible values of the Occurs enum.
 				throw new RuntimeException(exception);
 			}
@@ -190,7 +193,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		if (representation != null) {
 			try {
 				return new URI(representation.toString());
-			} catch (final URISyntaxException exception) {
+			} catch (@NotNull final URISyntaxException exception) {
 				// This should never happen since we control the possible values of the Representation enum.
 				throw new RuntimeException(exception);
 			}
@@ -237,7 +240,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		if (valueType != null) {
 			try {
 				return new URI(valueType.toString());
-			} catch (final URISyntaxException exception) {
+			} catch (@NotNull final URISyntaxException exception) {
 				// This should never happen since we control the possible values of the ValueType enum.
 				throw new RuntimeException(exception);
 			}
@@ -271,7 +274,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		return readOnly;
 	}
 
-	public void setAllowedValuesRef(final URI allowedValuesRef) {
+	public void setAllowedValuesRef(@Nullable final URI allowedValuesRef) {
 		if (allowedValuesRef != null) {
 			this.allowedValuesRef = allowedValuesRef;
 		} else {
@@ -279,7 +282,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		}
 	}
 
-	public void setDefaultValue(final Object defaultValue) {
+	public void setDefaultValue(@Nullable final Object defaultValue) {
 		if (defaultValue == null) {
 			getExtendedProperties().remove(PROPERTY_DEFAULT_VALUE);
 		} else {
@@ -311,7 +314,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		this.occurs = occurs;
 	}
 
-	public void setOccurs(final URI occurs) {
+	public void setOccurs(@Nullable final URI occurs) {
 		if (occurs != null) {
 			this.occurs = Occurs.fromString(occurs.toString());
 		} else {
@@ -323,7 +326,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		this.propertyDefinition = propertyDefinition;
 	}
 
-	public void setRange(final URI[] ranges) {
+	public void setRange(@Nullable final URI[] ranges) {
 		this.range.clear();
 		if (ranges != null) {
 			this.range.addAll(Arrays.asList(ranges));
@@ -338,7 +341,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		this.representation = representation;
 	}
 
-	public void setRepresentation(final URI representation) {
+	public void setRepresentation(@Nullable final URI representation) {
 		if (representation != null) {
 			this.representation = Representation.fromString(representation.toString());
 		} else {
@@ -358,7 +361,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		this.valueType = valueType;
 	}
 	
-	public void setValueType(final URI valueType) {
+	public void setValueType(@Nullable final URI valueType) {
 		if (valueType != null) {
 			this.valueType = ValueType.fromString(valueType.toString());
 		} else {
@@ -366,7 +369,8 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		}
 	}
 	
-	public Collection<?> getAllowedValuesCollection() {
+	@NotNull
+    public Collection<?> getAllowedValuesCollection() {
 		Collection<?> allowedValues = (Collection<?>) getExtendedProperties().get(PROPERTY_ALLOWED_VALUE);
 		if (allowedValues == null) {
 			return Collections.emptyList();
@@ -375,7 +379,7 @@ public final class Property extends AbstractResource implements Comparable<Prope
 		return allowedValues;
 	}
 	
-	public void setAllowedValuesCollection(final Collection<?> values) {
+	public void setAllowedValuesCollection(@Nullable final Collection<?> values) {
 		if (values == null) {
 			getExtendedProperties().remove(PROPERTY_ALLOWED_VALUE);
 		} else {

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/QueryCapability.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/QueryCapability.java
@@ -35,6 +35,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Query Capability Resource Shape", describes = OslcConstants.TYPE_QUERY_CAPABILITY)
@@ -94,7 +96,8 @@ public class QueryCapability extends AbstractResource {
 		return resourceShape;
 	}
 
-	@OslcDescription("The expected resource type URI that will be returned with this query capability. These would be the URIs found in the result resource's rdf:type property")
+	@NotNull
+    @OslcDescription("The expected resource type URI that will be returned with this query capability. These would be the URIs found in the result resource's rdf:type property")
 	@OslcName("resourceType")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "resourceType")
 	@OslcReadOnly
@@ -113,7 +116,8 @@ public class QueryCapability extends AbstractResource {
 		return title;
 	}
 
-	@OslcDescription("An identifier URI for the domain specified usage of this query capability. If a service provides multiple query capabilities, it may designate the primary or default one that should be used with a property value of http://open-services/ns/core#default")
+	@NotNull
+    @OslcDescription("An identifier URI for the domain specified usage of this query capability. If a service provides multiple query capabilities, it may designate the primary or default one that should be used with a property value of http://open-services/ns/core#default")
 	@OslcName("usage")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "usage")
 	@OslcReadOnly
@@ -134,7 +138,7 @@ public class QueryCapability extends AbstractResource {
 		this.resourceShape = resourceShape;
 	}
 
-	public void setResourceTypes(final URI[] resourceTypes) {
+	public void setResourceTypes(@Nullable final URI[] resourceTypes) {
 		this.resourceTypes.clear();
 		if (resourceTypes != null) {
 			this.resourceTypes.addAll(Arrays.asList(resourceTypes));
@@ -145,7 +149,7 @@ public class QueryCapability extends AbstractResource {
 		this.title = title;
 	}
 
-	public void setUsages(final URI[] usages) {
+	public void setUsages(@Nullable final URI[] usages) {
 		this.usages.clear();
 		if (usages != null) {
 			this.usages.addAll(Arrays.asList(usages));

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Representation.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Representation.java
@@ -19,6 +19,7 @@
 package org.eclipse.lyo.oslc4j.core.model;
 
 import java.net.URI;
+import org.jetbrains.annotations.Nullable;
 
 public enum Representation {
 	Reference(OslcConstants.OSLC_CORE_NAMESPACE + "Reference"),
@@ -46,7 +47,8 @@ public enum Representation {
 		return null;
 	}
 
-	public static Representation fromURI(final URI uri) {
+	@Nullable
+    public static Representation fromURI(final URI uri) {
 		return fromString(uri.toString());
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShape.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShape.java
@@ -35,6 +35,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Resource Shape Resource Shape", describes = OslcConstants.TYPE_RESOURCE_SHAPE)
@@ -56,7 +58,7 @@ public final class ResourceShape extends AbstractResource {
 		this.describes.add(describeItem);
 	}
 
-	public void addProperty(final Property property) {
+	public void addProperty(@NotNull final Property property) {
 		this.properties.put(property.getPropertyDefinition(), property);
 	}
 	
@@ -97,7 +99,7 @@ public final class ResourceShape extends AbstractResource {
 		return title;
 	}
 
-	public void setDescribes(final URI[] describes) {
+	public void setDescribes(@Nullable final URI[] describes) {
 		this.describes.clear();
 		if (describes != null) {
 			this.describes.addAll(Arrays.asList(describes));
@@ -105,7 +107,7 @@ public final class ResourceShape extends AbstractResource {
 	}
 
 
-	public void setProperties(final Property[] properties) {
+	public void setProperties(@Nullable final Property[] properties) {
 		this.properties.clear();
 		if (properties != null) {
 			for(Property prop :properties) {

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResourceShapeFactory.java
@@ -62,6 +62,7 @@ import org.eclipse.lyo.oslc4j.core.exception.OslcCoreInvalidRepresentationExcept
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreInvalidValueTypeException;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreMissingAnnotationException;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreMissingSetMethodException;
+import org.jetbrains.annotations.NotNull;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 public class ResourceShapeFactory {
@@ -102,10 +103,11 @@ public class ResourceShapeFactory {
 		super();
 	}
 
+	@NotNull
 	public static ResourceShape createResourceShape(final String baseURI,
 													final String resourceShapesPath,
 													final String resourceShapePath,
-													final Class<?> resourceClass)
+													@NotNull final Class<?> resourceClass)
 		   throws OslcCoreApplicationException, URISyntaxException {
 		final HashSet<Class<?>> verifiedClasses = new HashSet<Class<?>>();
 		verifiedClasses.add(resourceClass);
@@ -113,11 +115,12 @@ public class ResourceShapeFactory {
 		return createResourceShape(baseURI, resourceShapesPath, resourceShapePath, resourceClass, verifiedClasses);
 	}
 
+	@NotNull
 	private static ResourceShape createResourceShape(final String baseURI,
 													final String resourceShapesPath,
 													final String resourceShapePath,
 													final Class<?> resourceClass,
-													final Set<Class<?>> verifiedClasses)
+													@NotNull final Set<Class<?>> verifiedClasses)
 		   throws OslcCoreApplicationException, URISyntaxException {
 		final OslcResourceShape resourceShapeAnnotation = resourceClass.getAnnotation(OslcResourceShape.class);
 		if (resourceShapeAnnotation == null) {
@@ -165,8 +168,11 @@ public class ResourceShapeFactory {
 		return resourceShape;
 	}
 
+	@NotNull
 	@SuppressWarnings("rawtypes") // supress warning when casting Arrays.asList() to a Collection
-	private static Property createProperty(final String baseURI, final Class<?> resourceClass, final Method method, final OslcPropertyDefinition propertyDefinitionAnnotation, final Set<Class<?>> verifiedClasses) throws OslcCoreApplicationException, URISyntaxException {
+	private static Property createProperty(final String baseURI, @NotNull final Class<?> resourceClass, @NotNull
+	final Method method, @NotNull
+	final OslcPropertyDefinition propertyDefinitionAnnotation, @NotNull final Set<Class<?>> verifiedClasses) throws OslcCoreApplicationException, URISyntaxException {
 		final String name;
 		final OslcName nameAnnotation = InheritedMethodAnnotationHelper.getAnnotation(method, OslcName.class);
 		if (nameAnnotation != null) {
@@ -307,6 +313,7 @@ public class ResourceShapeFactory {
 		return property;
 	}
 
+	@NotNull
 	protected static String getDefaultPropertyName(final Method method) {
 		final String methodName	   = method.getName();
 		final int	 startingIndex = methodName.startsWith(METHOD_NAME_START_GET) ? METHOD_NAME_START_GET_LENGTH : METHOD_NAME_START_IS_LENGTH;
@@ -321,7 +328,8 @@ public class ResourceShapeFactory {
 		return lowercasedFirstCharacter + methodName.substring(endingIndex);
 	}
 
-	private static ValueType getDefaultValueType(final Class<?> resourceClass, final Method method, final Class<?> componentType) throws OslcCoreApplicationException {
+	private static ValueType getDefaultValueType(
+			@NotNull final Class<?> resourceClass, @NotNull final Method method, @NotNull final Class<?> componentType) throws OslcCoreApplicationException {
 		final ValueType valueType = CLASS_TO_VALUE_TYPE.get(componentType);
 		if (valueType == null) {
 			throw new OslcCoreInvalidPropertyTypeException(resourceClass, method, componentType);
@@ -336,6 +344,7 @@ public class ResourceShapeFactory {
 		return null;
 	}
 
+	@NotNull
 	private static Occurs getDefaultOccurs(final Class<?> type) {
 		if ((type.isArray()) ||
 			(Collection.class.isAssignableFrom(type))) {
@@ -344,7 +353,7 @@ public class ResourceShapeFactory {
 		return Occurs.ZeroOrOne;
 	}
 
-	protected static Class<?> getComponentType(final Class<?> resourceClass, final Method method, final Class<?> type) throws OslcCoreInvalidPropertyTypeException {
+	protected static Class<?> getComponentType(@NotNull final Class<?> resourceClass, @NotNull final Method method, final Class<?> type) throws OslcCoreInvalidPropertyTypeException {
 		if (type.isArray()) {
 			return type.getComponentType();
 		} else if (Collection.class.isAssignableFrom(type)) {
@@ -365,7 +374,7 @@ public class ResourceShapeFactory {
 		}
 	}
 
-	protected static void validateSetMethodExists(final Class<?> resourceClass, final Method getMethod) throws OslcCoreMissingSetMethodException {
+	protected static void validateSetMethodExists(@NotNull final Class<?> resourceClass, final Method getMethod) throws OslcCoreMissingSetMethodException {
 		final String getMethodName = getMethod.getName();
 
 		final String setMethodName;
@@ -379,7 +388,7 @@ public class ResourceShapeFactory {
         if(!isCollectionType(returnType)) {
             try {
                 resourceClass.getMethod(setMethodName, returnType);
-            } catch (final NoSuchMethodException exception) {
+            } catch (@NotNull final NoSuchMethodException exception) {
                 throw new OslcCoreMissingSetMethodException(resourceClass, getMethod, exception);
             }
         } else {
@@ -414,11 +423,11 @@ public class ResourceShapeFactory {
         }
 	}
 
-    static boolean isCollectionType(final Class<?> returnType) {
+    static boolean isCollectionType(@NotNull final Class<?> returnType) {
 	    return Collection.class.isAssignableFrom(returnType);
     }
 
-    private static void validateUserSpecifiedOccurs(final Class<?> resourceClass, final Method method, final OslcOccurs occursAnnotation) throws OslcCoreInvalidOccursException {
+    private static void validateUserSpecifiedOccurs(@NotNull final Class<?> resourceClass, final Method method, final OslcOccurs occursAnnotation) throws OslcCoreInvalidOccursException {
 		final Class<?> returnType = method.getReturnType();
 		final Occurs   occurs	  = occursAnnotation.value();
 
@@ -436,7 +445,8 @@ public class ResourceShapeFactory {
 		}
 	}
 
-	protected static void validateUserSpecifiedValueType(final Class<?> resourceClass, final Method method, final ValueType userSpecifiedValueType, final Class<?> componentType) throws OslcCoreInvalidValueTypeException {
+	protected static void validateUserSpecifiedValueType(
+			@NotNull final Class<?> resourceClass, @NotNull final Method method, final ValueType userSpecifiedValueType, final Class<?> componentType) throws OslcCoreInvalidValueTypeException {
 		final ValueType calculatedValueType = CLASS_TO_VALUE_TYPE.get(componentType);
 
 		// If user-specified value type matches calculated value type
@@ -472,7 +482,8 @@ public class ResourceShapeFactory {
 		throw new OslcCoreInvalidValueTypeException(resourceClass, method, userSpecifiedValueType);
 	}
 
-	private static void validateUserSpecifiedRepresentation(final Class<?> resourceClass, final Method method, final Representation userSpecifiedRepresentation, final Class<?> componentType) throws OslcCoreInvalidRepresentationException {
+	private static void validateUserSpecifiedRepresentation(
+			@NotNull final Class<?> resourceClass, @NotNull final Method method, @NotNull final Representation userSpecifiedRepresentation, final Class<?> componentType) throws OslcCoreInvalidRepresentationException {
 		// If user-specified representation is reference and component is not URI
 		// or
 		// user-specified representation is inline and component is a standard class

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResponseInfo.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ResponseInfo.java
@@ -18,6 +18,7 @@ package org.eclipse.lyo.oslc4j.core.model;
 
 import java.net.URI;
 import java.util.Map;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Wrapper for a collection or resources returned from an HTTP GET
@@ -46,7 +47,7 @@ public abstract class ResponseInfo<T extends Object>
 		T resource,
 		Map<String, Object> properties,
 		Integer totalCount,
-		URI nextPage
+		@Nullable URI nextPage
 	)
 	{
 		this(resource, properties, totalCount,

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Service.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/Service.java
@@ -37,6 +37,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Service Resource Shape", describes = OslcConstants.TYPE_SERVICE)
@@ -75,7 +77,8 @@ public class Service extends AbstractResource {
 		this.selectionDialogs.add(dialog);
 	}
 
-	@OslcDescription("Enables clients to create a resource via UI")
+	@NotNull
+    @OslcDescription("Enables clients to create a resource via UI")
 	@OslcName("creationDialog")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "creationDialog")
 	@OslcRange(OslcConstants.TYPE_DIALOG)
@@ -88,7 +91,8 @@ public class Service extends AbstractResource {
 		return creationDialogs.toArray(new Dialog[creationDialogs.size()]);
 	}
 
-	@OslcDescription("Enables clients to create new resources")
+	@NotNull
+    @OslcDescription("Enables clients to create new resources")
 	@OslcName("creationFactory")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "creationFactory")
 	@OslcRange(OslcConstants.TYPE_CREATION_FACTORY)
@@ -110,7 +114,8 @@ public class Service extends AbstractResource {
 		return domain;
 	}
 
-	@OslcDescription("Enables clients query across a collection of resources")
+	@NotNull
+    @OslcDescription("Enables clients query across a collection of resources")
 	@OslcName("queryCapability")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "queryCapability")
 	@OslcRange(OslcConstants.TYPE_QUERY_CAPABILITY)
@@ -123,7 +128,8 @@ public class Service extends AbstractResource {
 		return queryCapabilities.toArray(new QueryCapability[queryCapabilities.size()]);
 	}
 
-	@OslcDescription("Enables clients to select a resource via UI")
+	@NotNull
+    @OslcDescription("Enables clients to select a resource via UI")
 	@OslcName("selectionDialog")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "selectionDialog")
 	@OslcRange(OslcConstants.TYPE_DIALOG)
@@ -136,7 +142,8 @@ public class Service extends AbstractResource {
 		return selectionDialogs.toArray(new Dialog[selectionDialogs.size()]);
 	}
 
-	@OslcDescription("An identifier URI for the domain specified usage of this service")
+	@NotNull
+    @OslcDescription("An identifier URI for the domain specified usage of this service")
 	@OslcName("usage")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "usage")
 	@OslcReadOnly
@@ -148,14 +155,14 @@ public class Service extends AbstractResource {
 		return usages.toArray(new URI[usages.size()]);
 	}
 
-	public void setCreationDialogs(final Dialog[] creationDialogs) {
+	public void setCreationDialogs(@Nullable final Dialog[] creationDialogs) {
 		this.creationDialogs.clear();
 		if (creationDialogs != null) {
 			this.creationDialogs.addAll(Arrays.asList(creationDialogs));
 		}
 	}
 
-	public void setCreationFactories(final CreationFactory[] creationFactories) {
+	public void setCreationFactories(@Nullable final CreationFactory[] creationFactories) {
 		this.creationFactories.clear();
 		if (creationFactories != null) {
 			this.creationFactories.addAll(Arrays.asList(creationFactories));
@@ -166,21 +173,21 @@ public class Service extends AbstractResource {
 		this.domain = domain;
 	}
 
-	public void setQueryCapabilities(final QueryCapability[] queryCapabilities) {
+	public void setQueryCapabilities(@Nullable final QueryCapability[] queryCapabilities) {
 		this.queryCapabilities.clear();
 		if (queryCapabilities != null) {
 			this.queryCapabilities.addAll(Arrays.asList(queryCapabilities));
 		}
 	}
 
-	public void setSelectionDialogs(final Dialog[] selectionDialogs) {
+	public void setSelectionDialogs(@Nullable final Dialog[] selectionDialogs) {
 		this.selectionDialogs.clear();
 		if (selectionDialogs != null) {
 			this.selectionDialogs.addAll(Arrays.asList(selectionDialogs));
 		}
 	}
 
-	public void setUsages(final URI[] usages) {
+	public void setUsages(@Nullable final URI[] usages) {
 		this.usages.clear();
 		if (usages != null) {
 			this.usages.addAll(Arrays.asList(usages));

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProvider.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProvider.java
@@ -38,6 +38,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Service Provider Resource Shape", describes = OslcConstants.TYPE_SERVICE_PROVIDER)
@@ -78,7 +80,8 @@ public class ServiceProvider extends AbstractResource{
 		return description;
 	}
 
-	@OslcDescription("URLs that may be used to retrieve web pages to determine additional details about the service provider")
+	@NotNull
+    @OslcDescription("URLs that may be used to retrieve web pages to determine additional details about the service provider")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "details")
 	@OslcReadOnly
 	@OslcTitle("Details")
@@ -106,7 +109,8 @@ public class ServiceProvider extends AbstractResource{
 		return oauthConfiguration;
 	}
 
-	@OslcDescription("Defines namespace prefixes for use in JSON representations and in forming OSLC Query Syntax strings")
+	@NotNull
+    @OslcDescription("Defines namespace prefixes for use in JSON representations and in forming OSLC Query Syntax strings")
 	@OslcName("prefixDefinition")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "prefixDefinition")
 	@OslcRange(OslcConstants.TYPE_PREFIX_DEFINITION)
@@ -131,7 +135,8 @@ public class ServiceProvider extends AbstractResource{
 		return publisher;
 	}
 
-	@OslcDescription("Describes services offered by the service provider")
+	@NotNull
+    @OslcDescription("Describes services offered by the service provider")
 	@OslcName("service")
 	@OslcOccurs(Occurs.OneOrMany)
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "service")
@@ -162,7 +167,7 @@ public class ServiceProvider extends AbstractResource{
 		this.description = description;
 	}
 
-	public void setDetails(final URI[] details) {
+	public void setDetails(@Nullable final URI[] details) {
 		this.details.clear();
 		if (details != null) {
 			this.details.addAll(Arrays.asList(details));
@@ -177,7 +182,7 @@ public class ServiceProvider extends AbstractResource{
 		this.oauthConfiguration = oauthConfiguration;
 	}
 
-	public void setPrefixDefinitions(final PrefixDefinition[] prefixDefinitions) {
+	public void setPrefixDefinitions(@Nullable final PrefixDefinition[] prefixDefinitions) {
 		this.prefixDefinitions.clear();
 		if (prefixDefinitions != null) {
 			this.prefixDefinitions.addAll(Arrays.asList(prefixDefinitions));
@@ -188,7 +193,7 @@ public class ServiceProvider extends AbstractResource{
 		this.publisher = publisher;
 	}
 
-	public void setServices(final Service[] services) {
+	public void setServices(@Nullable final Service[] services) {
 		this.services.clear();
 		if (services != null) {
 			this.services.addAll(Arrays.asList(services));

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProviderCatalog.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProviderCatalog.java
@@ -38,6 +38,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcTitle;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueShape;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @OslcNamespace(OslcConstants.OSLC_CORE_NAMESPACE)
 @OslcResourceShape(title = "OSLC Service Provider Catalog Resource Shape", describes = OslcConstants.TYPE_SERVICE_PROVIDER_CATALOG)
@@ -59,7 +61,7 @@ public class ServiceProviderCatalog extends AbstractResource {
 		this.domains.add(domain);
 	}
 
-	public void addDomains(final Collection<URI> domains) {
+	public void addDomains(@NotNull final Collection<URI> domains) {
 		for (final URI domain : domains) {
 			addDomain(domain);
 		}
@@ -78,7 +80,8 @@ public class ServiceProviderCatalog extends AbstractResource {
 		return description;
 	}
 
-	@OslcDescription("URIs of the OSLC domain specifications that may be implemented by referenced services")
+	@NotNull
+    @OslcDescription("URIs of the OSLC domain specifications that may be implemented by referenced services")
 	@OslcName("domain")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "domain")
 	@OslcReadOnly
@@ -111,7 +114,8 @@ public class ServiceProviderCatalog extends AbstractResource {
 		return publisher;
 	}
 
-	@OslcDescription("Additional service provider catalogs")
+	@NotNull
+    @OslcDescription("Additional service provider catalogs")
 	@OslcName("serviceProviderCatalog")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProviderCatalog")
 	@OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER_CATALOG)
@@ -122,7 +126,8 @@ public class ServiceProviderCatalog extends AbstractResource {
 		return referencedServiceProviderCatalogs.toArray(new URI[referencedServiceProviderCatalogs.size()]);
 	}
 
-	@OslcDescription("Service providers")
+	@NotNull
+    @OslcDescription("Service providers")
 	@OslcName("serviceProvider")
 	@OslcPropertyDefinition(OslcConstants.OSLC_CORE_NAMESPACE + "serviceProvider")
 	@OslcRange(OslcConstants.TYPE_SERVICE_PROVIDER)
@@ -148,7 +153,7 @@ public class ServiceProviderCatalog extends AbstractResource {
 		domains.remove(domain);
 	}
 
-	public void removeDomains(final Collection<URI> domains) {
+	public void removeDomains(@NotNull final Collection<URI> domains) {
 		for (final URI domain : domains) {
 			removeDomain(domain);
 		}
@@ -162,7 +167,7 @@ public class ServiceProviderCatalog extends AbstractResource {
 		this.description = description;
 	}
 
-	public void setDomains(final URI[] domains) {
+	public void setDomains(@Nullable final URI[] domains) {
 		this.domains.clear();
 		if (domains != null) {
 			this.domains.addAll(Arrays.asList(domains));
@@ -177,14 +182,14 @@ public class ServiceProviderCatalog extends AbstractResource {
 		this.publisher = publisher;
 	}
 
-	public void setReferencedServiceProviderCatalogs(final URI[] referencedServiceProviderCatalogs) {
+	public void setReferencedServiceProviderCatalogs(@Nullable final URI[] referencedServiceProviderCatalogs) {
 		this.referencedServiceProviderCatalogs.clear();
 		if (referencedServiceProviderCatalogs != null) {
 			this.referencedServiceProviderCatalogs.addAll(Arrays.asList(referencedServiceProviderCatalogs));
 		}
 	}
 
-	public void setServiceProviders(final ServiceProvider[] serviceProviders) {
+	public void setServiceProviders(@Nullable final ServiceProvider[] serviceProviders) {
 		this.serviceProviders.clear();
 		if (serviceProviders != null) {
 			this.serviceProviders.addAll(Arrays.asList(serviceProviders));

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProviderFactory.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ServiceProviderFactory.java
@@ -39,6 +39,8 @@ import org.eclipse.lyo.oslc4j.core.annotation.OslcQueryCapability;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcService;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreMissingAnnotationException;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,15 +51,20 @@ public final class ServiceProviderFactory {
 		super();
 	}
 
-	public static ServiceProvider createServiceProvider(final String baseURI, final String genericBaseURI, final String title, final String description, final Publisher publisher, final Class<?>[] resourceClasses) throws OslcCoreApplicationException, URISyntaxException {
+	@NotNull
+    public static ServiceProvider createServiceProvider(final String baseURI, final String genericBaseURI, final String title, final String description, final Publisher publisher, @NotNull
+    final Class<?>[] resourceClasses) throws OslcCoreApplicationException, URISyntaxException {
 		return initServiceProvider(new ServiceProvider(), baseURI, genericBaseURI, title, description, publisher, resourceClasses, null);
 	}
 	
-	public static ServiceProvider createServiceProvider(final String baseURI, final String genericBaseURI, final String title, final String description, final Publisher publisher, final Class<?>[] resourceClasses, final Map<String,Object> pathParameterValues) throws OslcCoreApplicationException, URISyntaxException {
+	@NotNull
+    public static ServiceProvider createServiceProvider(final String baseURI, final String genericBaseURI, final String title, final String description, final Publisher publisher, @NotNull
+    final Class<?>[] resourceClasses, final Map<String,Object> pathParameterValues) throws OslcCoreApplicationException, URISyntaxException {
 		return initServiceProvider(new ServiceProvider(), baseURI, genericBaseURI, title, description, publisher, resourceClasses, pathParameterValues);
 	}
 
-	public static ServiceProvider initServiceProvider(final ServiceProvider serviceProvider, final String baseURI, final String genericBaseURI, final String title, final String description, final Publisher publisher, final Class<?>[] resourceClasses, final Map<String,Object> pathParameterValues) throws OslcCoreApplicationException, URISyntaxException {
+	@NotNull
+    public static ServiceProvider initServiceProvider(final ServiceProvider serviceProvider, final String baseURI, final String genericBaseURI, final String title, final String description, final Publisher publisher, final Class<?>[] resourceClasses, final Map<String,Object> pathParameterValues) throws OslcCoreApplicationException, URISyntaxException {
 		serviceProvider.setTitle(title);
 		serviceProvider.setDescription(description);
 		serviceProvider.setPublisher(publisher);
@@ -91,7 +98,7 @@ public final class ServiceProviderFactory {
 	}
 
 	private static void handleResourceClass(final String baseURI, final String genericBaseURI, final Class<?> resourceClass,
-			final Service service, final Map<String,Object> pathParameterValues) throws URISyntaxException {
+			@NotNull final Service service, final Map<String,Object> pathParameterValues) throws URISyntaxException {
 		for (final Method method : resourceClass.getMethods()) {
 			final GET getAnnotation = method.getAnnotation(GET.class);
 			if (getAnnotation != null) {
@@ -151,7 +158,8 @@ public final class ServiceProviderFactory {
 		}
 	}
 
-	protected static CreationFactory createCreationFactory(final String baseURI,
+	@NotNull
+    protected static CreationFactory createCreationFactory(final String baseURI,
 			final Map<String, Object> pathParameterValues, final Method method)
 			throws URISyntaxException {
 		final Path classPathAnnotation = method.getDeclaringClass().getAnnotation(Path.class);
@@ -165,7 +173,8 @@ public final class ServiceProviderFactory {
 		return creationFactory;
 	}
 
-	protected static CreationFactory createCreationFactory(final String baseURI,
+	@NotNull
+    protected static CreationFactory createCreationFactory(final String baseURI,
 			final Map<String, Object> pathParameterValues, final Path classPathAnnotation,
 			final OslcCreationFactory creationFactoryAnnotation, final Path methodPathAnnotation)
 			throws URISyntaxException {
@@ -201,11 +210,13 @@ public final class ServiceProviderFactory {
 		return creationFactory;
 	}
 
-	private static String pathAnnotationStringValue(final Path pathAnnotation) {
+	@Nullable
+    private static String pathAnnotationStringValue(@Nullable final Path pathAnnotation) {
 		return pathAnnotation == null ? null : pathAnnotation.value();
 	}
 
-	private static QueryCapability createQueryCapability(final String baseURI, final Method method, final Map<String,Object> pathParameterValues) throws URISyntaxException {
+	@NotNull
+    private static QueryCapability createQueryCapability(final String baseURI, final Method method, final Map<String,Object> pathParameterValues) throws URISyntaxException {
 		final OslcQueryCapability queryCapabilityAnnotation = method.getAnnotation(OslcQueryCapability.class);
 
 		final String title = queryCapabilityAnnotation.title();
@@ -244,17 +255,23 @@ public final class ServiceProviderFactory {
 		return queryCapability;
 	}
 
-	private static Dialog createCreationDialog(final String baseURI, final String genericBaseURI, final Method method, final OslcDialog dialogAnnotation, final String[] resourceShapes,
+	@NotNull
+    private static Dialog createCreationDialog(final String baseURI, final String genericBaseURI, @NotNull
+    final Method method, @NotNull final OslcDialog dialogAnnotation, final String[] resourceShapes,
 			final Map<String,Object> pathParameterValues) throws URISyntaxException {
 		return createDialog(baseURI, genericBaseURI, "Creation", "creation", method, dialogAnnotation, resourceShapes, pathParameterValues);
 	}
 
-	private static Dialog createSelectionDialog(final String baseURI, final String genericBaseURI, final Method method, final OslcDialog dialogAnnotation, final String[] resourceShapes,
+	@NotNull
+    private static Dialog createSelectionDialog(final String baseURI, final String genericBaseURI, @NotNull
+    final Method method, @NotNull final OslcDialog dialogAnnotation, final String[] resourceShapes,
 			final Map<String,Object> pathParameterValues) throws URISyntaxException {
 		return createDialog(baseURI, genericBaseURI, "Selection", "queryBase", method, dialogAnnotation, resourceShapes, pathParameterValues);
 	}
 
-	private static Dialog createDialog(final String baseURI, final String genericBaseURI, final String dialogType, final String parameterName, final Method method, final OslcDialog dialogAnnotation, final String[] resourceShapes,
+	@NotNull
+    private static Dialog createDialog(final String baseURI, final String genericBaseURI, final String dialogType, final String parameterName, final Method method, final OslcDialog dialogAnnotation, @Nullable
+    final String[] resourceShapes,
 			final Map<String,Object> pathParameterValues) throws URISyntaxException {
 
 		final String title = dialogAnnotation.title();
@@ -290,7 +307,7 @@ public final class ServiceProviderFactory {
 			try {
 				final String encodedParameter = URLEncoder.encode(parameter, "UTF-8");
 				uri += "?" + parameterName + "=" + encodedParameter;
-			} catch (final UnsupportedEncodingException exception) {
+			} catch (@NotNull final UnsupportedEncodingException exception) {
 				// TODO Andrew@2017-07-18: Rethrow an exception
 				log.warn("Error encoding URI [{}]", parameter, exception);
 			}
@@ -307,7 +324,7 @@ public final class ServiceProviderFactory {
 
 						resourceShapeParameters.append("&resourceShape=").append(
 								encodedResourceShape);
-					} catch (final UnsupportedEncodingException exception) {
+					} catch (@NotNull final UnsupportedEncodingException exception) {
 						// TODO Andrew@2017-07-18: Rethrow an exception
 						log.warn("Error encoding URI [{}]", resourceShapeURI, exception);
 					}
@@ -342,7 +359,9 @@ public final class ServiceProviderFactory {
 		return dialog;
 	}
 	
-	private static String resolvePathParameters(final String basePath, final String classPathAnnotation, final String methodPathAnnotation, final Map<String, Object> pathParameterValues)
+	@Nullable
+    private static String resolvePathParameters(final String basePath, @Nullable final String classPathAnnotation, @Nullable
+    final String methodPathAnnotation, final Map<String, Object> pathParameterValues)
 	{
 		final UriBuilder builder = UriBuilder.fromUri(basePath);
 		if (classPathAnnotation != null && !classPathAnnotation.equals("")) {

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/TypeFactory.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/TypeFactory.java
@@ -20,6 +20,8 @@ package org.eclipse.lyo.oslc4j.core.model;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public final class TypeFactory
 {
@@ -36,7 +38,7 @@ public final class TypeFactory
 	 *			  object class.
 	 * @return the qualified name.
 	 */
-	public static String getQualifiedName(final Class<?> objectClass)
+	public static String getQualifiedName(@NotNull final Class<?> objectClass)
 	{
 		String name = getName(objectClass);
 		return name != null ? getNamespace(objectClass) + name : null; 
@@ -58,7 +60,8 @@ public final class TypeFactory
 	 *			  object class.
 	 * @return the Oslc name.
 	 */
-	public static String getName(final Class<?> objectClass)
+	@Nullable
+    public static String getName(final Class<?> objectClass)
 	{
 		final OslcName oslcNameAnnotation = objectClass.getAnnotation(OslcName.class);
 		String name = null;

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ValueType.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/ValueType.java
@@ -19,6 +19,7 @@
 package org.eclipse.lyo.oslc4j.core.model;
 
 import java.net.URI;
+import org.jetbrains.annotations.Nullable;
 
 public enum ValueType {
 	Boolean(OslcConstants.XML_NAMESPACE + "boolean"),
@@ -55,7 +56,8 @@ public enum ValueType {
 		return null;
 	}
 
-	public static ValueType fromURI(final URI uri) {
+	@Nullable
+    public static ValueType fromURI(final URI uri) {
 		return fromString(uri.toString());
 	}
 }

--- a/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/XMLLiteral.java
+++ b/org.eclipse.lyo.oslc4j.core/src/main/java/org/eclipse/lyo/oslc4j/core/model/XMLLiteral.java
@@ -15,6 +15,8 @@
  *******************************************************************************/
 package org.eclipse.lyo.oslc4j.core.model;
 
+import org.jetbrains.annotations.Nullable;
+
 /**
  * A special value type that can be added to an extended properties map of an
  * {@link IExtendedResource} to indicate the value is an XMLLiteral rather than
@@ -58,7 +60,7 @@ public class XMLLiteral
 	}
 
 	@Override
-	public boolean equals(Object obj) {
+	public boolean equals(@Nullable Object obj) {
 		if (this == obj)
 		{
 			return true;


### PR DESCRIPTION
Checked exceptions are not good, but so is the lack of understanding whether fields/methods can be/return null or whether null arguments are allowed as inputs.

This patch adds annotations that allow IDEs to clearly highlight misuse but also Kotlin compiler can use them to mark OSLC Core methods & fields as not nullable, which would allow to avoid writing null-checking code.