### PR TITLE
Update Lyo Core to use Jax-rs 2.0, and be independent of Wink (as well as any other implementation)

### DIFF
--- a/org.eclipse.lyo.core.query/pom.xml
+++ b/org.eclipse.lyo.core.query/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.lyo.oslc4j.build/pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.lyo.core.query</groupId>
   <artifactId>oslc-query</artifactId>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <name>OSLC4J Query</name>
   <description>OSLC query support for the Eclipse Lyo OSLC4J SDK.</description>
   <scm>
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>
       <artifactId>oslc4j-core</artifactId>
-      <version>2.4.0-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/org.eclipse.lyo.core.trs/pom.xml
+++ b/org.eclipse.lyo.core.trs/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.lyo.oslc4j.build/pom.xml</relativePath>
   </parent>
   <groupId>org.eclipse.lyo</groupId>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <name>OSLC TRS Toolkit</name>
   <artifactId>oslc-trs</artifactId>
   <description>Software development kit to assist with TRS adoption.</description>
@@ -29,12 +29,12 @@
     <dependency>
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>
       <artifactId>oslc4j-core</artifactId>
-      <version>2.4.0-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>
       <artifactId>oslc4j-jena-provider</artifactId>
-      <version>2.4.0-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/org.eclipse.lyo.core.utils/pom.xml
+++ b/org.eclipse.lyo.core.utils/pom.xml
@@ -4,11 +4,11 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <relativePath>../org.eclipse.lyo.oslc4j.build/pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <name>OSLC4J Utilities</name>
     <artifactId>oslc4j-utils</artifactId>
     <description>Additional utilities such as the OSLC4J Marshaller and Unmarshaller</description>
@@ -28,16 +28,36 @@
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-json4j-provider</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-jena-provider</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+             <scope>test</scope>
+        </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/org.eclipse.lyo.core.utils/pom.xml
+++ b/org.eclipse.lyo.core.utils/pom.xml
@@ -40,11 +40,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.wink</groupId>
-            <artifactId>wink-server</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/org.eclipse.lyo.oslc4j.build/pom.xml
+++ b/org.eclipse.lyo.oslc4j.build/pom.xml
@@ -37,7 +37,7 @@
     <module>../org.eclipse.lyo.oslc4j.provider.jena</module>
     <module>../org.eclipse.lyo.oslc4j.provider.json4j</module>
     <module>../org.eclipse.lyo.core.utils</module>
-    <module>../org.eclipse.lyo.oslc4j.wink</module>
+    <!-- <module>../org.eclipse.lyo.oslc4j.wink</module> -->
     <module>../org.eclipse.lyo.oslc4j.registry</module>
     <module>../org.eclipse.lyo.repackaging.jersey</module>
     <module>../org.eclipse.lyo.shacl</module>

--- a/org.eclipse.lyo.oslc4j.build/pom.xml
+++ b/org.eclipse.lyo.oslc4j.build/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.eclipse.lyo.oslc4j.core</groupId>
   <artifactId>oslc4j-core-build</artifactId>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>OSLC4J Build</name>
   <scm>
@@ -28,6 +28,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <version.jena>3.6.0</version.jena>
+    <version.jersey>2.27</version.jersey>
   </properties>
 
   <modules>
@@ -37,11 +38,13 @@
     <module>../org.eclipse.lyo.oslc4j.provider.jena</module>
     <module>../org.eclipse.lyo.oslc4j.provider.json4j</module>
     <module>../org.eclipse.lyo.core.utils</module>
+    <!--FIXME:  What to do with wink & registry?-->
     <!-- <module>../org.eclipse.lyo.oslc4j.wink</module> -->
-    <module>../org.eclipse.lyo.oslc4j.registry</module>
+    <!-- <module>../org.eclipse.lyo.oslc4j.registry</module> -->
     <module>../org.eclipse.lyo.repackaging.jersey</module>
     <module>../org.eclipse.lyo.shacl</module>
-    <module>../oslc4j-bundle</module>
+    <!--FIXME:  oslc4j-bundle needs lyo-store to be of version 3.1.0-SNAPSHOT for it to build.-->
+    <!-- <module>../oslc4j-bundle</module> -->
   </modules>
 
   <dependencyManagement>
@@ -85,39 +88,8 @@
       <dependency>
         <!--CQ 6733-->
         <groupId>org.apache.wink</groupId>
-        <artifactId>wink</artifactId>
-        <version>1.2.1-incubating</version>
-        <type>pom</type>
-      </dependency>
-      <dependency>
-        <!--CQ 6733-->
-        <groupId>org.apache.wink</groupId>
-        <artifactId>wink-server</artifactId>
-        <version>1.2.1-incubating</version>
-      </dependency>
-      <dependency>
-        <!--CQ 6733-->
-        <groupId>org.apache.wink</groupId>
         <artifactId>wink-json4j</artifactId>
         <version>1.2.1-incubating</version>
-      </dependency>
-      <dependency>
-        <!--CQ 6733-->
-        <groupId>org.apache.wink</groupId>
-        <artifactId>wink-json4j-provider</artifactId>
-        <version>1.2.1-incubating</version>
-      </dependency>
-      <dependency>
-        <!--CQ 6733-->
-        <groupId>org.apache.wink</groupId>
-        <artifactId>wink-client</artifactId>
-        <version>1.2.1-incubating</version>
-        <exclusions>
-          <exclusion>
-            <artifactId>stax-api</artifactId>
-            <groupId>javax.xml.stream</groupId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <!--CQ 6582-->
@@ -163,6 +135,36 @@
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
         <version>2.8.0</version>
+      </dependency>
+      <dependency>
+          <groupId>javax.ws.rs</groupId>
+          <artifactId>javax.ws.rs-api</artifactId>
+          <version>2.1</version>
+      </dependency>
+        <dependency>
+          <groupId>javax.servlet</groupId>
+          <artifactId>javax.servlet-api</artifactId>
+          <version>3.1.0</version>
+        </dependency>
+      <dependency>
+          <groupId>org.glassfish.jersey.containers</groupId>
+          <artifactId>jersey-container-servlet</artifactId>
+          <version>${version.jersey}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-server</artifactId>
+          <version>${version.jersey}</version>
+      </dependency>
+        <dependency>
+          <groupId>org.glassfish.jersey.core</groupId>
+          <artifactId>jersey-common</artifactId>
+          <version>${version.jersey}</version>
+      </dependency>
+      <dependency>
+          <groupId>org.glassfish.jersey.inject</groupId>
+          <artifactId>jersey-hk2</artifactId>
+          <version>${version.jersey}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/org.eclipse.lyo.oslc4j.core/pom.xml
+++ b/org.eclipse.lyo.oslc4j.core/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <relativePath>../org.eclipse.lyo.oslc4j.build/pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <name>OSLC4J Core</name>
     <description>Core components of the Eclipse Lyo OSLC4J SDK.</description>
     <scm>
@@ -21,50 +21,22 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		      <version.jersey>2.27</version.jersey>
     </properties>
     <!-- Disable doclint for Java 1.8 (for now) -->
     <dependencies>
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1</version>
         </dependency>
 	    <dependency>
 	      <groupId>javax.servlet</groupId>
 	      <artifactId>javax.servlet-api</artifactId>
-	      <version>3.1.0</version>
 	      <scope>provided</scope>
 	    </dependency>
         <dependency>
            <groupId>org.apache.jena</groupId>
            <artifactId>apache-jena-libs</artifactId>
            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.containers</groupId>
-            <artifactId>jersey-container-servlet</artifactId>
-            <version>${version.jersey}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-server</artifactId>
-            <version>${version.jersey}</version>
-             <scope>test</scope>
-        </dependency>
-          <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-common</artifactId>
-            <version>${version.jersey}</version>
-             <scope>test</scope>
-        </dependency>
-        <dependency>
-        <groupId>org.glassfish.jersey.inject</groupId>
-		<artifactId>jersey-hk2</artifactId>
-		<version>${version.jersey}</version>
-		<!-- FIXME: jersey-hk2 is only needed for testing, but the build fails if scope is set to test. -->
-             <!-- <scope>test</scope> -->
         </dependency>
        <dependency>
             <groupId>org.slf4j</groupId>
@@ -92,6 +64,26 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
             <version>${powermock.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+             <scope>test</scope>
+        </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/org.eclipse.lyo.oslc4j.core/pom.xml
+++ b/org.eclipse.lyo.oslc4j.core/pom.xml
@@ -42,7 +42,11 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.2</version>
+      </dependency>
         <!-- Test Dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/org.eclipse.lyo.oslc4j.core/pom.xml
+++ b/org.eclipse.lyo.oslc4j.core/pom.xml
@@ -21,26 +21,52 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
+		      <version.jersey>2.27</version.jersey>
     </properties>
     <!-- Disable doclint for Java 1.8 (for now) -->
     <dependencies>
         <dependency>
             <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
-            <version>1.1.1</version>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1</version>
+        </dependency>
+	    <dependency>
+	      <groupId>javax.servlet</groupId>
+	      <artifactId>javax.servlet-api</artifactId>
+	      <version>3.1.0</version>
+	      <scope>provided</scope>
+	    </dependency>
+        <dependency>
+           <groupId>org.apache.jena</groupId>
+           <artifactId>apache-jena-libs</artifactId>
+           <type>pom</type>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.servlet</artifactId>
-            <version>3.1-b33</version>
-            <scope>provided</scope>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <version>${version.jersey}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.apache.jena</groupId>
-            <artifactId>apache-jena-libs</artifactId>
-            <type>pom</type>
-         </dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+            <version>${version.jersey}</version>
+             <scope>test</scope>
+        </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>${version.jersey}</version>
+             <scope>test</scope>
+        </dependency>
         <dependency>
+        <groupId>org.glassfish.jersey.inject</groupId>
+		<artifactId>jersey-hk2</artifactId>
+		<version>${version.jersey}</version>
+		<!-- FIXME: jersey-hk2 is only needed for testing, but the build fails if scope is set to test. -->
+             <!-- <scope>test</scope> -->
+        </dependency>
+       <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -66,11 +92,6 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
             <version>${powermock.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.wink</groupId>
-            <artifactId>wink-server</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/org.eclipse.lyo.oslc4j.provider.jena/pom.xml
+++ b/org.eclipse.lyo.oslc4j.provider.jena/pom.xml
@@ -28,9 +28,9 @@
             <version>2.4.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.servlet</artifactId>
-            <version>3.1-b33</version>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -63,11 +63,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.wink</groupId>
-            <artifactId>wink-server</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/org.eclipse.lyo.oslc4j.provider.jena/pom.xml
+++ b/org.eclipse.lyo.oslc4j.provider.jena/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <relativePath>../org.eclipse.lyo.oslc4j.build/pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-jena-provider</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <name>OSLC4J Jena Provider</name>
     <description>JAX-RS provider for reading and writing RDF content using the Eclipse Lyo OSLC4J SDK.</description>
     <scm>
@@ -25,12 +25,11 @@
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -63,6 +62,26 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+             <scope>test</scope>
+        </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JsonLdTest.java
+++ b/org.eclipse.lyo.oslc4j.provider.jena/src/test/java/org/eclipse/lyo/oslc4j/provider/jena/test/JsonLdTest.java
@@ -22,7 +22,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.jena.ext.com.google.common.collect.ImmutableList;
-import org.apache.wink.common.internal.MultivaluedMapImpl;
+import javax.ws.rs.core.MultivaluedHashMap;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 import org.eclipse.lyo.oslc4j.core.model.ServiceProvider;
 import org.eclipse.lyo.oslc4j.provider.jena.OslcJsonLdArrayProvider;
@@ -71,7 +71,7 @@ public class JsonLdTest {
 
         provider.writeTo(sp, ServiceProvider.class, ServiceProvider.class, ServiceProvider.class
                 .getAnnotations(), OslcMediaType.APPLICATION_JSON_LD_TYPE, new
-                MultivaluedMapImpl<>(), outputStream);
+                MultivaluedHashMap<>(), outputStream);
 
         final String jsonLD = outputStream.toString("UTF-8");
 
@@ -92,7 +92,7 @@ public class JsonLdTest {
                          ServiceProvider.class,
                          ServiceProvider.class.getAnnotations(),
                          OslcMediaType.APPLICATION_JSON_LD_TYPE,
-                         new MultivaluedMapImpl<>(),
+                         new MultivaluedHashMap<>(),
                          outputStream);
 
         final String jsonLD = outputStream.toString("UTF-8");
@@ -115,7 +115,7 @@ public class JsonLdTest {
                 objects.getClass().getGenericSuperclass(),
                 ServiceProvider.class.getAnnotations(),
                 OslcMediaType.APPLICATION_JSON_LD_TYPE,
-                new MultivaluedMapImpl<>(),
+                new MultivaluedHashMap<>(),
                 outputStream);
 
         final String jsonLD = outputStream.toString("UTF-8");

--- a/org.eclipse.lyo.oslc4j.provider.json4j/pom.xml
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/pom.xml
@@ -35,9 +35,9 @@
             <artifactId>wink-json4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.servlet</artifactId>
-            <version>3.1-b33</version>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
 
@@ -45,11 +45,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.wink</groupId>
-            <artifactId>wink-server</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/org.eclipse.lyo.oslc4j.provider.json4j/pom.xml
+++ b/org.eclipse.lyo.oslc4j.provider.json4j/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <relativePath>../org.eclipse.lyo.oslc4j.build/pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-json4j-provider</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <name>OSLC4J JSON4J Provider</name>
     <description>JAX-RS provider for reading and writing OSLC 2.0 JSON content using the Eclipse Lyo OSLC4J SDK.</description>
     <scm>
@@ -26,10 +26,8 @@
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
-
-
         <dependency>
             <groupId>org.apache.wink</groupId>
             <artifactId>wink-json4j</artifactId>
@@ -37,14 +35,31 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
-
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-servlet</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+             <scope>test</scope>
+        </dependency>
+          <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.inject</groupId>
+            <artifactId>jersey-hk2</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/org.eclipse.lyo.oslc4j.registry/pom.xml
+++ b/org.eclipse.lyo.oslc4j.registry/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <relativePath>../org.eclipse.lyo.oslc4j.build/pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-registry</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <packaging>war</packaging>
     <name>OSLC4J Registry</name>
     <description>Eclipse Lyo OSLC4J registry application for OSLC providers.</description>
@@ -48,22 +48,22 @@
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-wink</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-json4j-provider</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-jena-provider</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/org.eclipse.lyo.oslc4j.registry/pom.xml
+++ b/org.eclipse.lyo.oslc4j.registry/pom.xml
@@ -40,9 +40,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.servlet</artifactId>
-            <version>3.1-b33</version>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/org.eclipse.lyo.oslc4j.wink/pom.xml
+++ b/org.eclipse.lyo.oslc4j.wink/pom.xml
@@ -4,12 +4,12 @@
     <parent>
         <groupId>org.eclipse.lyo.oslc4j.core</groupId>
         <artifactId>oslc4j-core-build</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <relativePath>../org.eclipse.lyo.oslc4j.build/pom.xml</relativePath>
     </parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-wink</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <name>OSLC4J Wink Application</name>
     <description>OSLC4J Wink application for supporting OSLC resource shapes and service provider registration.</description>
     <scm>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-core</artifactId>
-            <version>2.4.0-SNAPSHOT</version>
+            <version>3.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>

--- a/org.eclipse.lyo.repackaging.jersey/pom.xml
+++ b/org.eclipse.lyo.repackaging.jersey/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.eclipse.lyo.oslc4j.core</groupId>
 	<artifactId>repackaging.jersey</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 
 	<properties>
 		<maven.compiler.source>1.8</maven.compiler.source>

--- a/org.eclipse.lyo.shacl/pom.xml
+++ b/org.eclipse.lyo.shacl/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.eclipse.lyo</groupId>
   <artifactId>shacl</artifactId>
-  <version>2.4.0-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>shacl</name>
@@ -16,7 +16,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
 
-        <version.lyo>2.4.0-SNAPSHOT</version.lyo>
+        <version.lyo>3.1.0-SNAPSHOT</version.lyo>
     </properties>
 
 

--- a/oslc4j-bundle/pom.xml
+++ b/oslc4j-bundle/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.eclipse.lyo.oslc4j.core</groupId>
     <artifactId>oslc4j-core-build</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../org.eclipse.lyo.oslc4j.build/pom.xml</relativePath>
   </parent>
 
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>
       <artifactId>oslc4j-core</artifactId>
-      <version>2.4.0-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
       <exclusions>
           <exclusion>
             <groupId>org.apache.jena</groupId>
@@ -49,12 +49,12 @@
     <dependency>
       <groupId>org.eclipse.lyo</groupId>
       <artifactId>shacl</artifactId>
-      <version>2.4.0-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.lyo.oslc4j.core</groupId>
       <artifactId>oslc4j-jena-provider</artifactId>
-      <version>2.4.0-SNAPSHOT</version>
+      <version>3.1.0-SNAPSHOT</version>
       <exclusions>
       	<exclusion>
       		<groupId>xml-apis</groupId>
@@ -70,7 +70,7 @@
     <dependency>
         <groupId>org.eclipse.lyo.store</groupId>
         <artifactId>store-core</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.1.0-SNAPSHOT</version>
         <exclusions>
           <exclusion>
             <groupId>org.apache.jena</groupId>


### PR DESCRIPTION
Update Lyo Core to use Jax-rs 2.0, and be independent of Wink (as well as any other implementation)