### PR TITLE
Bug 531986 - Change isQueryResult logic

### DIFF
--- a/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractOslcRdfXmlProvider.java
+++ b/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/AbstractOslcRdfXmlProvider.java
@@ -207,10 +207,12 @@ public abstract class AbstractOslcRdfXmlProvider
 		}
 
 		String descriptionURI  = null;
+		// TODO Andrew@2019-04-18: stop using responseInfoURI nullity to detect Query results
 		String responseInfoURI = null;
 
 		if (queryResult && ! isClientSide)
 		{
+			log.trace("Marshalling response objects as OSLC Query result (server-side only)");
 
 			final String method = httpServletRequest.getMethod();
 			if ("GET".equals(method))

--- a/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaProviderHelper.java
+++ b/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaProviderHelper.java
@@ -1,0 +1,34 @@
+package org.eclipse.lyo.oslc4j.provider.jena;
+
+import java.lang.annotation.Annotation;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNotQueryResult;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcQueryCapability;
+
+/**
+ * TODO
+ *
+ * @since TODO
+ */
+public class JenaProviderHelper {
+    static boolean hasNotQueryResultTypeAnnot(final Class<?> type) {
+        OslcNotQueryResult notQueryResult = type.getComponentType()
+                .getAnnotation(OslcNotQueryResult.class);
+        return (notQueryResult != null && notQueryResult.value());
+    }
+
+    static boolean hasOslcQueryCapabilityMethodAnnot(final Annotation[] annotations) {
+        if (annotations != null) {
+            for (int i = 0; i < annotations.length; i++) {
+                if (annotations[i] != null && annotations[i] instanceof OslcQueryCapability) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    static boolean isQueryResult(final Class<?> type, final Annotation[] annotations) {
+        return hasOslcQueryCapabilityMethodAnnot(annotations) &&
+                !hasNotQueryResultTypeAnnot(type);
+    }
+}

--- a/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlArrayProvider.java
+++ b/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlArrayProvider.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*!*****************************************************************************
  * Copyright (c) 2012, 2013 IBM Corporation.
  *
  * All rights reserved. This program and the accompanying materials
@@ -15,6 +15,7 @@
  *	   Alberto Giammaria	- initial API and implementation
  *	   Chris Peters			- initial API and implementation
  *	   Gianluca Bernardini	- initial API and implementation
+ *     Andrew Berezovskyi   - change isQueryResult logic
  *******************************************************************************/
 package org.eclipse.lyo.oslc4j.provider.jena;
 
@@ -33,7 +34,6 @@ import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import javax.ws.rs.ext.Provider;
 
-import org.eclipse.lyo.oslc4j.core.annotation.OslcNotQueryResult;
 import org.eclipse.lyo.oslc4j.core.model.OslcMediaType;
 
 @Provider
@@ -85,14 +85,9 @@ public class OslcRdfXmlArrayProvider
 						final MultivaluedMap<String, Object> map,
 						final OutputStream					 outputStream)
 		   throws IOException,
-				  WebApplicationException
-	{
-		OslcNotQueryResult notQueryResult = type.getComponentType().getAnnotation(OslcNotQueryResult.class);
-		
-		writeTo(notQueryResult != null && notQueryResult.value() ? false : true,
-				objects,
-				mediaType,
-				map,
+				  WebApplicationException {
+
+		writeTo(JenaProviderHelper.isQueryResult(type, annotations), objects, mediaType, map,
 				outputStream);
 	}
 

--- a/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlCollectionProvider.java
+++ b/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/OslcRdfXmlCollectionProvider.java
@@ -123,10 +123,9 @@ public class OslcRdfXmlCollectionProvider
 	{
 		final ParameterizedType parameterizedType = (ParameterizedType) genericType;
 		final Type[] actualTypeArguments = parameterizedType.getActualTypeArguments();
-		OslcNotQueryResult notQueryResult = ((Class<?>)actualTypeArguments[0]).getAnnotation(OslcNotQueryResult.class);
-		
-		writeTo(notQueryResult != null && notQueryResult.value() ? false : true,
-				collection.toArray(new Object[collection.size()]),
+
+		writeTo(JenaProviderHelper.isQueryResult((Class<?>)actualTypeArguments[0], annotations),
+				collection.toArray(new Object[0]),
 				mediaType,
 				map,
 				outputStream);


### PR DESCRIPTION
Previously, all arrays were treated as OSLC Query results unless the
array type was explicitly marked with @OslcNotQueryResult annotation.
This prevented from returning arrays of mixed-typed OSLC resources (as
Object[] or IResource[]) because there is no way to annotate those
classes accordingly.

From now on, only arrays returned from JAX-RS methods annotated with
@OslcQueryCapability will be automatically treated as OSLC Query results
(again, unless the returned array type is annotated with the
@OslcNotQueryResult).
