### PR TITLE
Use context-specific ClassLoader to instantiate OSLC beans

### DIFF
--- a/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelper.java
+++ b/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/JenaModelHelper.java
@@ -11,12 +11,10 @@
  */
 package org.eclipse.lyo.oslc4j.provider.jena;
 
-import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
@@ -53,7 +51,6 @@ import org.eclipse.lyo.oslc4j.core.OslcGlobalNamespaceProvider;
 import org.eclipse.lyo.oslc4j.core.SingletonWildcardProperties;
 import org.eclipse.lyo.oslc4j.core.UnparseableLiteral;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
-import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespaceDefinition;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcRdfCollectionType;
@@ -525,6 +522,7 @@ public final class JenaModelHelper
 			final Map<Class<?>, Map<String, Method>> classPropertyDefinitionsToSetMethods = new HashMap<>();
             Class<?> originalBeanClass = beanClass;
 			for (final Resource resource : listSubjects) {
+                beanClass = originalBeanClass;
                 Optional<Class<?>> mostConcreteResourceClass = ResourcePackages.getClassOf(resource, beanClass);
                 if (mostConcreteResourceClass.isPresent()) {
                     beanClass = mostConcreteResourceClass.get();

--- a/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
+++ b/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/jena/ordfm/ResourcePackages.java
@@ -75,7 +75,7 @@ public class ResourcePackages {
                         LOGGER.trace("[-] Abstract class: " + classInfo.getName());
                     } else {
                         try {
-                            Class<?> rdfClass = Class.forName(classInfo.getName());
+                            Class<?> rdfClass = Class.forName(classInfo.getName(), true, Thread.currentThread().getContextClassLoader());
                             String rdfType = TypeFactory.getQualifiedName(rdfClass);
                             List<Class<?>> types = TYPES_MAPPINGS.get(rdfType);
                             if (types == null) {


### PR DESCRIPTION
Fixes #118.

Also, while iterating resources, the reference to the beanClass gets changed to the most concrete reference, we need to reset to the originalBeanClass in order to process next resource in case there are more than one to unmarshall in model.