### PR TITLE
On-the-fly multiple inheritance to match RDF types

### DIFF
--- a/oslc4j-jena-provider/pom.xml
+++ b/oslc4j-jena-provider/pom.xml
@@ -12,6 +12,7 @@
     <description>JAX-RS provider for reading and writing RDF content using the Eclipse Lyo OSLC4J SDK.</description>
 
     <properties>
+      <kotlin.version>1.3.50</kotlin.version>
     </properties>
 
     <dependencies>
@@ -84,6 +85,17 @@
             <artifactId>jersey-hk2</artifactId>
             <scope>test</scope>
         </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>${kotlin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-test</artifactId>
+        <version>${kotlin.version}</version>
+        <scope>test</scope>
+      </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -95,6 +107,50 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
             </plugin>
+          <plugin>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-maven-plugin</artifactId>
+            <version>${kotlin.version}</version>
+            <executions>
+              <execution>
+                <id>compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>test-compile</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>test-compile</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <jvmTarget>1.8</jvmTarget>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>compile</id>
+                <phase>compile</phase>
+                <goals>
+                  <goal>compile</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>testCompile</id>
+                <phase>test-compile</phase>
+                <goals>
+                  <goal>testCompile</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
     </build>
 </project>

--- a/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/proxy/OslcShapeGenerator.java
+++ b/oslc4j-jena-provider/src/main/java/org/eclipse/lyo/oslc4j/provider/proxy/OslcShapeGenerator.java
@@ -1,0 +1,47 @@
+package org.eclipse.lyo.oslc4j.provider.proxy;
+
+import java.beans.BeanInfo;
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.jena.rdf.model.Resource;
+import org.eclipse.lyo.oslc4j.core.model.IExtendedResource;
+import org.eclipse.lyo.oslc4j.provider.jena.JenaModelHelper;
+
+@SuppressWarnings("ALL")
+public class OslcShapeGenerator {
+    public static <T extends IExtendedResource> T newShape(Resource r, Class<? extends T> shapeClass, Class<T> shapeInterface,
+            List<Class> rdfInterfaces)
+            throws IntrospectionException {
+//        final BeanInfo shapeBeanInfo = Introspector.getBeanInfo(shapeClass);
+        if (Modifier.isAbstract(shapeClass.getModifiers())) {
+            throw new IllegalArgumentException("Shape class must be concrete");
+        }
+        if (!shapeInterface.isInterface()) {
+            throw new IllegalArgumentException("Shape interface must be a Java interface");
+        }
+        if(!shapeInterface.isAssignableFrom(shapeClass)) {
+            throw new IllegalArgumentException("Shape interface must be assignable from a Shape class");
+        }
+        for (Class rdfInterface : rdfInterfaces) {
+            if (!rdfInterface.isInterface()) {
+                throw new IllegalArgumentException("RDF Class interfaces must be Java interfaces");
+            }
+        }
+        final ArrayList<Class> proxyClasses = new ArrayList<>(rdfInterfaces.size() + 1);
+        proxyClasses.add(shapeInterface);
+        proxyClasses.addAll(rdfInterfaces);
+        final T shapeBean = JenaModelHelper.unmarshal(r, shapeClass);
+        final T shape = (T) Proxy.newProxyInstance(shapeInterface.getClassLoader(),
+                proxyClasses.toArray(new Class[0]), (proxy, method, args) -> {
+                    System.out.printf("%s called\n", method.toString());
+                    return method.invoke(shapeBean, args);
+                });
+        return shape;
+    }
+}

--- a/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/IRequirementShape.java
+++ b/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/IRequirementShape.java
@@ -1,0 +1,61 @@
+package org.eclipse.lyo.oslc4j.provider.proxy;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.IExtendedResource;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcNamespace("http://open-services.net/ns/core/shapes/3.0/requirements-management-shape.ttl#")
+@OslcName("Requirement")
+@OslcResourceShape(describes = "http://open-services.net/ns/rm#Requirement")
+public interface IRequirementShape extends IExtendedResource {
+    // Start of user code getterAnnotation:title
+    // End of user code
+    @OslcName("title")
+    @OslcPropertyDefinition("http://purl.org/dc/terms/title")
+    @OslcDescription("Title of the resource represented as rich text in XHTML content. SHOULD include only content that is valid inside an XHTML <span> element.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcValueType(ValueType.XMLLiteral)
+    @OslcReadOnly(false)
+    public String getTitle();
+
+    // Start of user code getterAnnotation:description
+    // End of user code
+    @OslcName("description")
+    @OslcPropertyDefinition("http://purl.org/dc/terms/description")
+    @OslcDescription("Descriptive text about resource represented as rich text in XHTML content. SHOULD include only content that is valid and suitable inside an XHTML <div> element.")
+    @OslcOccurs(Occurs.ZeroOrOne)
+    @OslcValueType(ValueType.XMLLiteral)
+    @OslcReadOnly(false)
+    public String getDescription();
+
+    // Start of user code getterAnnotation:identifier
+    // End of user code
+    @OslcName("identifier")
+    @OslcPropertyDefinition("http://purl.org/dc/terms/identifier")
+    @OslcDescription("A unique identifier for a resource. Typically read-only and assigned by the service provider when a resource is created. Not typically intended for end-user display.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcValueType(ValueType.String)
+    @OslcReadOnly(false)
+    public String getIdentifier();
+
+    // Start of user code setterAnnotation:title
+    // End of user code
+    public void setTitle(final String title );
+
+    // Start of user code setterAnnotation:description
+    // End of user code
+    public void setDescription(final String description );
+
+    // Start of user code setterAnnotation:identifier
+    // End of user code
+    public void setIdentifier(final String identifier );
+
+}

--- a/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/OslcShapeGeneratorTest.kt
+++ b/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/OslcShapeGeneratorTest.kt
@@ -1,0 +1,44 @@
+package org.eclipse.lyo.oslc4j.provider.proxy
+
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.riot.Lang
+import org.apache.jena.riot.RDFParser
+import org.junit.Test
+
+import org.junit.Assert.*
+
+class OslcShapeGeneratorTest {
+
+    @Test
+    fun newShape() {
+        val model = ModelFactory.createDefaultModel()
+        RDFParser.fromString("""
+            @prefix dcterms: <http://purl.org/dc/terms/>
+            @prefix oslc_rm: <http://open-services.net/ns/rm#Requirement>
+            @prefix : <http://example.lyo/#>
+            
+            :req1 a oslc_rm:Requirement;
+                dcterms:identifier "REQ-1";
+                dcterms:title "Hello";
+                dcterms:description "Dummy requirement" .
+        """.trimIndent())
+            .lang(Lang.TURTLE)
+            .parse(model.graph)
+
+        val resource = model.getResource("http://example.lyo/#req1")
+
+        val aRequirement: IRequirementShape = OslcShapeGenerator.newShape(resource,
+                RequirementShape::class.java, IRequirementShape::class.java,
+                listOf(Requirement::class.java, Resource::class.java))
+
+        assertTrue(aRequirement.identifier == "REQ-1")
+        assertTrue(aRequirement is IRequirementShape)
+        assertTrue(aRequirement is Requirement)
+        assertTrue(aRequirement is Resource)
+
+        aRequirement.javaClass.interfaces.forEach {
+            println("aResourse implements ${it.name}")
+        }
+
+    }
+}

--- a/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/Requirement.java
+++ b/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/Requirement.java
@@ -1,0 +1,9 @@
+package org.eclipse.lyo.oslc4j.provider.proxy;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+
+@OslcNamespace("http://open-services.net/ns/rm#Requirement")
+@OslcName("Requirement")
+public interface Requirement {
+}

--- a/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/RequirementShape.java
+++ b/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/RequirementShape.java
@@ -1,0 +1,107 @@
+package org.eclipse.lyo.oslc4j.provider.proxy;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcOccurs;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcPropertyDefinition;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcReadOnly;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcResourceShape;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcValueType;
+import org.eclipse.lyo.oslc4j.core.model.AbstractResource;
+import org.eclipse.lyo.oslc4j.core.model.IExtendedResource;
+import org.eclipse.lyo.oslc4j.core.model.Occurs;
+import org.eclipse.lyo.oslc4j.core.model.ValueType;
+
+@OslcNamespace("http://open-services.net/ns/core/shapes/3.0/requirements-management-shape.ttl#")
+@OslcName("Requirement")
+@OslcResourceShape(describes = "http://open-services.net/ns/rm#Requirement")
+public class RequirementShape extends AbstractResource implements IRequirementShape {
+
+    String title;
+    String description;
+    String identifier;
+
+    // Start of user code getterAnnotation:title
+    // End of user code
+    @OslcName("title")
+    @OslcPropertyDefinition("http://purl.org/dc/terms/title")
+    @OslcDescription("Title of the resource represented as rich text in XHTML content. SHOULD include only content that is valid inside an XHTML <span> element.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcValueType(ValueType.XMLLiteral)
+    @OslcReadOnly(false)
+    public String getTitle()
+    {
+        // Start of user code getterInit:title
+        // End of user code
+        return title;
+    }
+
+    // Start of user code getterAnnotation:description
+    // End of user code
+    @OslcName("description")
+    @OslcPropertyDefinition("http://purl.org/dc/terms/description")
+    @OslcDescription("Descriptive text about resource represented as rich text in XHTML content. SHOULD include only content that is valid and suitable inside an XHTML <div> element.")
+    @OslcOccurs(Occurs.ZeroOrOne)
+    @OslcValueType(ValueType.XMLLiteral)
+    @OslcReadOnly(false)
+    public String getDescription()
+    {
+        // Start of user code getterInit:description
+        // End of user code
+        return description;
+    }
+
+    // Start of user code getterAnnotation:identifier
+    // End of user code
+    @OslcName("identifier")
+    @OslcPropertyDefinition("http://purl.org/dc/terms/identifier")
+    @OslcDescription("A unique identifier for a resource. Typically read-only and assigned by the service provider when a resource is created. Not typically intended for end-user display.")
+    @OslcOccurs(Occurs.ExactlyOne)
+    @OslcValueType(ValueType.String)
+    @OslcReadOnly(false)
+    public String getIdentifier()
+    {
+        // Start of user code getterInit:identifier
+        // End of user code
+        return identifier;
+    }
+
+    // Start of user code setterAnnotation:title
+    // End of user code
+    public void setTitle(final String title)
+    {
+        // Start of user code setterInit:title
+        // End of user code
+        this.title = title;
+
+        // Start of user code setterFinalize:title
+        // End of user code
+    }
+
+    // Start of user code setterAnnotation:description
+    // End of user code
+    public void setDescription(final String description)
+    {
+        // Start of user code setterInit:description
+        // End of user code
+        this.description = description;
+
+        // Start of user code setterFinalize:description
+        // End of user code
+    }
+
+    // Start of user code setterAnnotation:identifier
+    // End of user code
+    public void setIdentifier(final String identifier)
+    {
+        // Start of user code setterInit:identifier
+        // End of user code
+        this.identifier = identifier;
+
+        // Start of user code setterFinalize:identifier
+        // End of user code
+    }
+
+
+}

--- a/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/Resource.java
+++ b/oslc4j-jena-provider/src/test/java/org/eclipse/lyo/oslc4j/provider/proxy/Resource.java
@@ -1,0 +1,9 @@
+package org.eclipse.lyo.oslc4j.provider.proxy;
+
+import org.eclipse.lyo.oslc4j.core.annotation.OslcName;
+import org.eclipse.lyo.oslc4j.core.annotation.OslcNamespace;
+
+@OslcNamespace("http://www.w3.org/2000/01/rdf-schema#")
+@OslcName("Resource")
+public interface Resource {
+}


### PR DESCRIPTION
I had many conversations with Jim and Jad about the _impedance mismatch_ between Java programming model and the RDF model as a whole. OSLC itself tried to fix it with shapes. We then tried fixing it in Lyo with Lyo Store. After Jim shared with me papers about the ActiveRDF design, I thought that Groovy would allow us to implement similar functionality in the most direct way possible.

Recently, I had chat with Jad that it would be awesome to unmarshal the following piece of RDF:

```turtle
:req1 a oslc_rm:Requirement, rdfs:Resource;
    dcterms:identifier "REQ-1";
    dcterms:title "Hello";
    dcterms:description "Dummy requirement" .
```

into an instance of the most relevant shape but also make it implement all the interface matching _each_ RDFS class. This would be the most usable way to reduce the impedance mismatch without forcing people to use bits of Groovy code. We agreed that it would be way over our heads to generate such bytecode on the fly.

Today I was leaning about Eclipse Microprofile and ended up reading a bit of code of the Apache Tamaya code that made use of the [java.lang.reflect.Proxy](https://docs.oracle.com/javase/7/docs/api/java/lang/reflect/Proxy.html) class and I immediately knew I hit the jackpot.

In this PR you can see the implementation of the core idea for this feature. Extra work would have to be done on reflection in order to remove the need to specify all the Java classes during unmarshalling.

Right now the code is invoked like this:

```kotlin
val aRequirement: IRequirementShape = OslcShapeGenerator.newShape(resource,
        RequirementShape::class.java, IRequirementShape::class.java,
        listOf(Requirement::class.java, Resource::class.java))
```

All of the assertions pass:

```kotlin
assertTrue(aRequirement.identifier == "REQ-1")
assertTrue(aRequirement is IRequirementShape)
assertTrue(aRequirement is Requirement)
assertTrue(aRequirement is Resource)
```

This means both that the interfaces have been assigned properly and that the `RequirementShape` getters are called correctly (which is instantiated by the JMH itself).

The PR is not ready for merging but the idea is ready for 