### PR TITLE
slf4j from 1.7.25 to 1.7.26

### DIFF
--- a/oslc4j-core-build/pom.xml
+++ b/oslc4j-core-build/pom.xml
@@ -80,13 +80,13 @@
         <!--CQ 13716-->
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.25</version>
+        <version>1.7.26</version>
       </dependency>
       <dependency>
         <!--CQ 13717-->
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-simple</artifactId>
-        <version>1.7.25</version>
+        <version>1.7.26</version>
       </dependency>
       <dependency>
         <!--CQ 6733-->


### PR DESCRIPTION
Jena libraries need 1.7.26. So, good to harmonize the versions.
This is necessary because it is causing some problems when I try to create plugins otherwise.